### PR TITLE
feat: consolidate ui:// and ui-app://

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ The primary payload exchanged between the server and the client:
 interface HtmlResourceBlock {
   type: 'resource';
   resource: {
-    uri: string;       // e.g. "ui://component/id" or "ui-app://app/instance"
-    mimeType: 'text/html';
+    uri: string;       // ui://component/id"instance"
+    mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content, text/uri-list for URL content
     text?: string;      // Inline HTML or external URL
-    blob?: string;      // Base64-encoded HTML or URL (for large payloads)
+    blob?: string;      // Base64-encoded HTML or URL
   };
 }
 ```
 
 * **`uri`**: Unique identifier for caching and routing
-  * `ui://…` — self-contained HTML (rendered via `<iframe srcDoc>`)
-  * `ui-app://…` — external app/site (rendered via `<iframe src>`)
-* **`mimeType`**: Always `text/html`
+  * `ui://…` — UI resources (rendering method determined by mimeType)
+* **`mimeType`**: `text/html` for HTML content (iframe srcDoc), `text/uri-list` for URL content (iframe src)
+  * **MCP-UI requires a single URL**: While `text/uri-list` format supports multiple URLs, MCP-UI uses only the first valid URL and logs others
 * **`text` vs. `blob`**: Choose `text` for simple strings; use `blob` for larger or encoded content.
 
 It's rendered in the client with the `<HtmlResource>` React component.
@@ -95,7 +95,7 @@ yarn add @mcp-ui/server @mcp-ui/client
 
    // External URL
    const external = createHtmlResource({
-     uri: 'ui-app://widget/session-42',
+     uri: 'ui://widget/session-42',
      content: { type: 'externalUrl', iframeUrl: 'https://example.com/widget' },
      delivery: 'text',
    });
@@ -110,7 +110,7 @@ yarn add @mcp-ui/server @mcp-ui/client
    function App({ mcpResource }) {
      if (
        mcpResource.type === 'resource' &&
-       mcpResource.resource.mimeType === 'text/html'
+       mcpResource.resource.uri?.startsWith('ui://')
      ) {
        return (
          <HtmlResource
@@ -164,4 +164,4 @@ Apache License 2.0 © [The MCP UI Authors](LICENSE)
 
 ## Disclaimer
 
-This project is provided “as is”, without warranty of any kind. The `mcp-ui` authors and contributors shall not be held liable for any damages, losses, or issues arising from the use of this software. Use at your own risk.
+This project is provided "as is", without warranty of any kind. The `mcp-ui` authors and contributors shall not be held liable for any damages, losses, or issues arising from the use of this software. Use at your own risk.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The primary payload exchanged between the server and the client:
 interface HtmlResourceBlock {
   type: 'resource';
   resource: {
-    uri: string;       // ui://component/id"instance"
+    uri: string;       // ui://component/id"
     mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content, text/uri-list for URL content
     text?: string;      // Inline HTML or external URL
     blob?: string;      // Base64-encoded HTML or URL

--- a/docs/src/guide/client/html-resource.md
+++ b/docs/src/guide/client/html-resource.md
@@ -74,6 +74,26 @@ function App({ mcpResource }) {
 
 This pattern allows the `HtmlResource` component to handle mimeType-based rendering internally, making your code more future-proof as new content types (like `application/javascript`) are added.
 
+## Backwards Compatibility
+
+The `HtmlResource` component maintains backwards compatibility with the legacy `ui-app://` URI scheme:
+
+- **Legacy Support**: Resources with `ui-app://` URIs are automatically treated as URL content (equivalent to `mimeType: 'text/uri-list'`) even when they have the historically incorrect `mimeType: 'text/html'`
+- **Automatic Detection**: The component detects legacy URIs and processes them correctly without requiring code changes
+- **MimeType Override**: Ignores the incorrect `text/html` mimeType and treats content as URLs
+- **Migration Encouragement**: A warning is logged when legacy URIs are detected, encouraging server updates
+- **Seamless Transition**: Existing clients continue working with older servers during migration periods
+
+### Legacy URI Handling
+
+```tsx
+// Both patterns work identically:
+// Legacy (automatically detected and corrected):
+<HtmlResource resource={{ uri: 'ui-app://widget/123', mimeType: 'text/html', text: 'https://example.com/widget' }} />
+// Modern (recommended):
+<HtmlResource resource={{ uri: 'ui://widget/123', mimeType: 'text/uri-list', text: 'https://example.com/widget' }} />
+```
+
 ## Security Notes
 
 - **`sandbox` attribute**: Restricts what the iframe can do. `allow-scripts` is needed for interactivity. `allow-same-origin` is external apps. Caution - the external app method isn's not a secure way to render untrusted code. We're working on new methods to alleviate security concerns.

--- a/docs/src/guide/client/html-resource.md
+++ b/docs/src/guide/client/html-resource.md
@@ -23,14 +23,17 @@ export interface HtmlResourceProps {
 
 ## How It Works
 
-1.  **Checks Content Type**: If `resource.mimeType` isn't `"text/html"`, you'll see an error.
+1.  **Checks Content Type**: If `resource.mimeType` isn't `"text/html"` or `"text/uri-list"`, you'll see an error.
 2.  **Handles URI Schemes**:
-    - For `ui-app://` URIs:
-      - Expects `resource.text` or `resource.blob` to contain a URL.
+    - For resources with `mimeType: 'text/uri-list'`:
+      - Expects `resource.text` or `resource.blob` to contain a single URL in URI list format
+      - **MCP-UI requires a single URL**: While the format supports multiple URLs, only the first valid URL is used
+      - Multiple URLs are supported for fallback specification but will trigger warnings
+      - Ignores comment lines starting with `#` and empty lines
       - If using `blob`, it decodes it from Base64.
-      - Renders an `<iframe>` with its `src` set to the URL.
+      - Renders an `<iframe>` with its `src` set to the first valid URL.
       - Sandbox: `allow-scripts allow-same-origin` (needed for some external sites; be mindful of security).
-    - For `ui://` URIs (or if there's no URI but you provide HTML in `text`/`blob`):
+    - For resources with `mimeType: 'text/html'`:
       - Expects `resource.text` or `resource.blob` to contain HTML.
       - If using `blob`, it decodes it from Base64.
       - Renders an `<iframe>` with its `srcdoc` set to the HTML.
@@ -45,8 +48,34 @@ By default, the iframe stretches to 100% width and is at least 200px tall. You c
 
 See [Client SDK Usage & Examples](./usage-examples.md).
 
+## Recommended Usage Pattern
+
+Client-side hosts should check for the `ui://` URI scheme first to identify MCP-UI resources, rather than checking mimeType:
+
+```tsx
+function App({ mcpResource }) {
+  if (
+    mcpResource.type === 'resource' &&
+    mcpResource.resource.uri?.startsWith('ui://')
+  ) {
+    return (
+      <HtmlResource
+        resource={mcpResource.resource}
+        onUiAction={(tool, params) => {
+          console.log('Action:', tool, params);
+          return { status: 'ok' };
+        }}
+      />
+    );
+  }
+  return <p>Unsupported resource</p>;
+}
+```
+
+This pattern allows the `HtmlResource` component to handle mimeType-based rendering internally, making your code more future-proof as new content types (like `application/javascript`) are added.
+
 ## Security Notes
 
-- **`sandbox` attribute**: Restricts what the iframe can do. `allow-scripts` is needed for interactivity. `allow-same-origin` is only used for `ui-app://` URLs. Caution - it's not a secure way to render untrusted code. We should add more secure methods such as RSC ASAP.
+- **`sandbox` attribute**: Restricts what the iframe can do. `allow-scripts` is needed for interactivity. `allow-same-origin` is external apps. Caution - the external app method isn's not a secure way to render untrusted code. We're working on new methods to alleviate security concerns.
 - **`postMessage` origin**: When sending messages from the iframe, always specify the target origin for safety. The component listens globally, so your iframe content should be explicit.
 - **Content Sanitization**: HTML is rendered as-is. If you don't fully trust the source, sanitize the HTML before passing it in, or rely on the iframe's sandboxing.

--- a/docs/src/guide/client/overview.md
+++ b/docs/src/guide/client/overview.md
@@ -7,8 +7,8 @@ The `@mcp-ui/client` package helps you render HTML resource sent from an MCP-ena
 - **`HtmlResource` (React Component)**:
   The primary component for rendering an interactive HTML resource. It handles:
   - Decoding Base64 blobs if necessary.
-  - Rendering content using `srcDoc` for `ui://` URIs.
-  - Rendering content using `src` for `ui-app://` URIs.
+  - Rendering content using `srcDoc` for the `text/html` mimeType.
+  - Rendering content using `src` for the `text/uri-list` mimeType.
   - Setting up a `message` event listener to receive actions from `ui://` iframes.
 - **(Other potential exports might include context providers or hooks if the client SDK grows more complex).**
 
@@ -20,7 +20,7 @@ The `@mcp-ui/client` package helps you render HTML resource sent from an MCP-ena
 
 ## Building
 
-This package uses Vite in library mode. It outputs ESM (`.mjs`) and UMD (`.js`) formats, plus TypeScript declarations (`.d.ts`). `react` and `@mcp-ui/shared` are externalized.
+This package uses Vite in library mode. It outputs ESM (`.mjs`) and UMD (`.js`) formats, plus TypeScript declarations (`.d.ts`). `react` is externalized.
 
 To build just this package from the monorepo root:
 

--- a/docs/src/guide/client/usage-examples.md
+++ b/docs/src/guide/client/usage-examples.md
@@ -1,6 +1,6 @@
 # @mcp-ui/client Usage & Examples
 
-Here’s how to use the `<HtmlResource />` component from `@mcp-ui/client`.
+Here's how to use the `<HtmlResource />` component from `@mcp-ui/client`.
 
 ## Installation
 
@@ -42,8 +42,8 @@ const fetchMcpResource = async (id: string): Promise<HtmlResource> => {
     return {
       type: 'resource',
       resource: {
-        uri: 'ui-app://example/external-site',
-        mimeType: 'text/html',
+        uri: 'ui://example/external-site',
+        mimeType: 'text/uri-list',
         text: 'https://vitepress.dev',
       },
     };
@@ -125,4 +125,4 @@ export default App;
 
 ---
 
-That’s it! Just use `<HtmlResource />` with the right props and you’re ready to render interactive HTML from MCP resources in your React app. If you need more details, check out the [HtmlResource Component](./html-resource.md) page.
+That's it! Just use `<HtmlResource />` with the right props and you're ready to render interactive HTML from MCP resources in your React app. If you need more details, check out the [HtmlResource Component](./html-resource.md) page.

--- a/docs/src/guide/introduction.md
+++ b/docs/src/guide/introduction.md
@@ -23,7 +23,7 @@ export interface HtmlResource {
   type: 'resource'; // Fixed type identifier
   resource: {
     uri: string; // Unique identifier. Governs rendering behavior.
-    mimeType: 'text/html'; // Must be text/html.
+    mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content, text/uri-list for URL content
     text?: string; // Raw HTML string or an iframe URL string.
     blob?: string; // Base64 encoded HTML string or iframe URL string.
   };
@@ -33,13 +33,11 @@ export interface HtmlResource {
 ### Key Field Details:
 
 - **`uri` (Uniform Resource Identifier)**:
-  - If starts with `ui://` (e.g., `ui://my-custom-form/instance-01`):
-    - The client should render the HTML content (from `text` or `blob`) directly, typically within a sandboxed `<iframe>` using the `srcdoc` attribute.
-    - This is for self-contained HTML snippets or components.
-  - If starts with `ui-app://` (e.g., `ui-app://external-dashboard/user-xyz`):
-    - The client should render the URL (from `text` or `blob`) within an `<iframe>` using the `src` attribute.
-    - This is for embedding full external web applications or pages.
-- **`mimeType`**: Must be `"text/html"` for this protocol.
+  - All UI resources use the `ui://` scheme (e.g., `ui://my-custom-form/instance-01`)
+  - The rendering method is determined by the `mimeType`:
+    - `mimeType: 'text/html'` → HTML content rendered via `<iframe srcdoc>`
+    - `mimeType: 'text/uri-list'` → URL content rendered via `<iframe src>`
+- **`mimeType`**: `'text/html'` for HTML content, `'text/uri-list'` for URL content
 - **`text` or `blob` Content Delivery**:
   - `text`: The HTML string or URL is provided directly.
   - `blob`: The HTML string or URL is Base64 encoded. Useful for complex HTML, ensuring integrity, or avoiding issues with JSON encoding of special characters.

--- a/docs/src/guide/protocol-details.md
+++ b/docs/src/guide/protocol-details.md
@@ -9,7 +9,7 @@ export interface HtmlResourceBlock {
   type: 'resource';
   resource: {
     uri: string;
-    mimeType: 'text/html';
+    mimeType: 'text/html' | 'text/uri-list';
     text?: string;
     blob?: string;
   };
@@ -20,16 +20,14 @@ export interface HtmlResourceBlock {
 
 - **`ui://<component-name>/<instance-id>`**
 
-  - **Purpose**: For self-contained HTML that the client renders directly.
-  - **Content**: `text` or `blob` contains the HTML string.
-  - **Client Action**: Render in a sandboxed iframe using `srcdoc`.
-  - **Example**: A custom button, a small form, a data visualization snippet.
-
-- **`ui-app://<app-name>/<instance-id>`**
-  - **Purpose**: For embedding external web applications or complex UIs via a URL.
-  - **Content**: `text` or `blob` contains the URL.
-  - **Client Action**: Render in an iframe using `src`.
-  - **Example**: Embedding a Grafana dashboard, a third-party widget, a mini-application.
+  - **Purpose**: For all UI resources. The rendering method is determined by `mimeType`.
+  - **Content**: `text` or `blob` contains either HTML string or URL string.
+  - **Client Action**: 
+    - If `mimeType: 'text/html'` → Render in a sandboxed iframe using `srcdoc`
+    - If `mimeType: 'text/uri-list'` → Render in an iframe using `src`
+  - **Examples**: 
+    - HTML content: A custom button, a small form, a data visualization snippet
+    - URL content: Embedding a Grafana dashboard, a third-party widget, a mini-application
 
 ## Content Delivery: `text` vs. `blob`
 
@@ -38,9 +36,60 @@ export interface HtmlResourceBlock {
   - **Pros**: Handles special characters robustly, can be better for larger payloads, ensures integrity during JSON transport.
   - **Cons**: Requires Base64 decoding on the client, slightly increases payload size.
 
+## URI List Format Support
+
+When using `mimeType: 'text/uri-list'`, the content follows the standard URI list format (RFC 2483). However, **MCP-UI requires a single URL** for rendering.
+
+- **Single URL Requirement**: MCP-UI will use only the first valid URL found
+- **Multiple URLs**: If multiple URLs are provided, the client will use the first valid URL and log a warning about the ignored alternatives
+- **Comments**: Lines starting with `#` are treated as comments and ignored
+- **Empty lines**: Blank lines are ignored
+
+**Example URI List Content:**
+```
+# Primary dashboard URL
+https://dashboard.example.com/main
+
+# Backup dashboard URL (will be ignored but logged)
+https://backup.dashboard.example.com/main
+```
+
+**Client Behavior:**
+- Uses `https://dashboard.example.com/main` for rendering
+- Logs: `"Multiple URLs found in uri-list content. Using the first URL: "https://dashboard.example.com/main". Other URLs ignored: ["https://backup.dashboard.example.com/main"]"`
+
+This design allows for fallback URLs to be specified in the standard format while maintaining simple client implementation that focuses on a single primary URL.
+
+## Recommended Client-Side Pattern
+
+Client-side hosts should check for the `ui://` URI scheme first to identify MCP-UI resources, rather than checking mimeType:
+
+```tsx
+// ✅ Recommended: Check URI scheme first
+if (
+  mcpResource.type === 'resource' &&
+  mcpResource.resource.uri?.startsWith('ui://')
+) {
+  return <HtmlResource resource={mcpResource.resource} onUiAction={handleAction} />;
+}
+
+// ❌ Not recommended: Check mimeType first
+if (
+  mcpResource.type === 'resource' &&
+  (mcpResource.resource.mimeType === 'text/html' || mcpResource.resource.mimeType === 'text/uri-list')
+) {
+  return <HtmlResource resource={mcpResource.resource} onUiAction={handleAction} />;
+}
+```
+
+**Benefits of URI-first checking:**
+- Future-proof: Works with new content types like `application/javascript`
+- Semantic clarity: `ui://` clearly indicates this is a UI resource
+- Simpler logic: Let the `HtmlResource` component handle mimeType-based rendering internally
+
 ## Communication (Client <-> Iframe)
 
-For `ui://` or `ui-app://` resources, you can use `window.parent.postMessage` to send data or actions from the iframe back to the host client application. The client application should set up an event listener for `message` events.
+For `ui://` resources, you can use `window.parent.postMessage` to send data or actions from the iframe back to the host client application. The client application should set up an event listener for `message` events.
 
 **Iframe Script Example:**
 
@@ -67,4 +116,4 @@ window.addEventListener('message', (event) => {
 });
 ```
 
-For `ui-app://` resources, communication depends on what the external application supports (e.g., its own `postMessage` API, URL parameters, etc.).
+For URL-based resources (`mimeType: 'text/uri-list'`), communication depends on what the external application supports (e.g., its own `postMessage` API, URL parameters, etc.).

--- a/docs/src/guide/protocol-details.md
+++ b/docs/src/guide/protocol-details.md
@@ -117,3 +117,50 @@ window.addEventListener('message', (event) => {
 ```
 
 For URL-based resources (`mimeType: 'text/uri-list'`), communication depends on what the external application supports (e.g., its own `postMessage` API, URL parameters, etc.).
+
+## Backwards Compatibility
+
+The MCP-UI client library maintains backwards compatibility with legacy `ui-app://` URI schemes used by older servers until MAJOR version 4.
+
+### Legacy URI Support
+
+- **`ui-app://`**: Legacy scheme for external applications containing URLs, but historically used incorrect `mimeType: 'text/html'`
+- **Automatic Detection**: Client automatically detects and handles legacy URIs by overriding the incorrect mimeType
+- **Migration Path**: Servers can gradually migrate from `ui-app://` to `ui://` + `mimeType: 'text/uri-list'`
+- **Deprecation Warning**: Client logs warnings to encourage server updates
+
+### Migration Examples
+
+```typescript
+// Legacy pattern (still supported):
+{
+  type: 'resource',
+  resource: {
+    uri: 'ui-app://dashboard/main',
+    mimeType: 'text/html',
+    text: 'https://grafana.example.com/dashboard'
+  }
+}
+
+// Modern equivalent:
+{
+  type: 'resource',
+  resource: {
+    uri: 'ui://dashboard/main',
+    mimeType: 'text/uri-list',
+    text: 'https://grafana.example.com/dashboard'
+  }
+}
+```
+
+### Client Pattern for Both Legacy and Modern
+
+```tsx
+// This pattern works for both legacy and modern URIs:
+if (
+  mcpResource.type === 'resource' &&
+  (mcpResource.resource.uri?.startsWith('ui://') || mcpResource.resource.uri?.startsWith('ui-app://'))
+) {
+  return <HtmlResource resource={mcpResource.resource} onUiAction={handleAction} />;
+}
+```

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -6,31 +6,32 @@
 </p>
 
 <p align="center">
-  <a href="#-what-is-mcp-ui">What Is `mcp-ui`</a> •
+  <a href="#-what-is-mcp-ui">What's mcp-ui?</a> •
   <a href="#-installation">Installation</a> •
   <a href="#-quickstart">Quickstart</a> •
   <a href="#-core-concepts">Core Concepts</a> •
-  <a href="#-example-server">Example Implementation</a> •
+  <a href="#-examples">Examples</a> •
   <a href="#-roadmap">Roadmap</a> •
   <a href="#-contributing">Contributing</a> •
   <a href="#-license">License</a>
 </p>
 
+----
 
-**`mcp-ui`** brings interactive web components to your [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) workflow. Build on the server, render on the client — let your MCP server deliver dynamic HTML resources out of the box.
+**`mcp-ui`** brings interactive web components to the [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP). Deliver rich, dynamic UI resources directly from your MCP server to be rendered by the client. Take AI interaction to the next level!
 
 > *This project is an experimental playground for MCP UI ideas. Expect rapid iteration and community-driven enhancements!*
 
 <video src="https://github.com/user-attachments/assets/51f7c712-8133-4d7c-86d3-fdca550b9767"></video>
 
-## 💡 What Is `mcp-ui`?
+## 💡 What's `mcp-ui`?
 
 `mcp-ui` is a TypeScript SDK comprising two packages:
 
 * **`@mcp-ui/server`**: Utilities to generate `HtmlResourceBlock` objects on your MCP server.
 * **`@mcp-ui/client`**: UI components (e.g., `<HtmlResource />`) to render those blocks in the browser and handle their events.
 
-Together, they let you define reusable HTML resource blocks on the server side and seamlessly display them and react to their actions in any MCP host environment.
+Together, they let you define reusable UI resource blocks on the server side, seamlessly display them in the client, and react to their actions in the MCP host environment.
 
 
 ## ✨ Core Concepts
@@ -43,18 +44,18 @@ The primary payload exchanged between the server and the client:
 interface HtmlResourceBlock {
   type: 'resource';
   resource: {
-    uri: string;       // e.g. "ui://component/id" or "ui-app://app/instance"
-    mimeType: 'text/html';
+    uri: string;       // e.g. "ui://component/id"
+    mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content, text/uri-list for URL content
     text?: string;      // Inline HTML or external URL
-    blob?: string;      // Base64-encoded HTML or URL (for large payloads)
+    blob?: string;      // Base64-encoded HTML or URL
   };
 }
 ```
 
 * **`uri`**: Unique identifier for caching and routing
-  * `ui://…` — self-contained HTML (rendered via `<iframe srcDoc>`)
-  * `ui-app://…` — external app/site (rendered via `<iframe src>`)
-* **`mimeType`**: Always `text/html`
+  * `ui://…` — UI resources (rendering method determined by mimeType)
+* **`mimeType`**: `text/html` for HTML content (iframe srcDoc), `text/uri-list` for URL content (iframe src)
+  * **MCP-UI requires a single URL**: While `text/uri-list` format supports multiple URLs, MCP-UI uses only the first valid URL and logs others
 * **`text` vs. `blob`**: Choose `text` for simple strings; use `blob` for larger or encoded content.
 
 It's rendered in the client with the `<HtmlResource>` React component.
@@ -70,6 +71,9 @@ UI blocks must be able to interact with the agent. In `mcp-ui`, this is done by 
 ```bash
 # using npm
 npm install @mcp-ui/server @mcp-ui/client
+
+# or pnpm
+pnpm add @mcp-ui/server @mcp-ui/client
 
 # or yarn
 yarn add @mcp-ui/server @mcp-ui/client
@@ -91,7 +95,7 @@ yarn add @mcp-ui/server @mcp-ui/client
 
    // External URL
    const external = createHtmlResource({
-     uri: 'ui-app://widget/session-42',
+     uri: 'ui://widget/session-42',
      content: { type: 'externalUrl', iframeUrl: 'https://example.com/widget' },
      delivery: 'text',
    });
@@ -106,7 +110,7 @@ yarn add @mcp-ui/server @mcp-ui/client
    function App({ mcpResource }) {
      if (
        mcpResource.type === 'resource' &&
-       mcpResource.resource.mimeType === 'text/html'
+       mcpResource.resource.uri?.startsWith('ui://')
      ) {
        return (
          <HtmlResource
@@ -124,13 +128,14 @@ yarn add @mcp-ui/server @mcp-ui/client
 
 3. **Enjoy** interactive MCP UIs — no extra configuration required.
 
-## 🌍 Example implementation
+## 🌍 Examples
 
 **Client example**
-https://github.com/modelcontextprotocol/inspector/pull/413
+* [ui-inspector](https://github.com/idosal/ui-inspector) - inspect local `mcp-ui`-enabled servers. Check out the [hosted version](https://scira-mcp-chat-git-main-idosals-projects.vercel.app/)!
+* [MCP-UI Chat](https://github.com/idosal/scira-mcp-ui-chat) - interactive chat built with the `mcp-ui` client.
 
 **Server example**
-Try out the hosted app at -
+Try out the hosted app -
 * **HTTP Streaming**: `https://remote-mcp-server-authless.idosalomon.workers.dev/mcp`
 * **SSE**: `https://remote-mcp-server-authless.idosalomon.workers.dev/sse`
 
@@ -138,16 +143,19 @@ The app is deployed from `examples/server`.
 
 Drop those URLs into any MCP-compatible host to see `mcp-ui` in action.
 
+
 ## 🛣️ Roadmap
 
-- [ ] Support new SSR methods (e.g., RSC)
-- [ ] Support additional client-side libraries
-- [ ] Expand UI Action API
+- [X] Add online playground
+- [ ] Support React Server Components
+- [ ] Support Remote-DOM
+- [ ] Support additional client-side libraries (e.g., Vue)
+- [ ] Expand UI Action API (beyond tool calls)
 - [ ] Do more with Resources and Sampling
 
 ## 🤝 Contributing
 
-Contributions, ideas, and bug reports are welcome! See our [contribution guidelines](https://github.com/idosal/mco-ui/blob/main/.github/CONTRIBUTING.md) to get started.
+Contributions, ideas, and bug reports are welcome! See the [contribution guidelines](https://github.com/idosal/mcp-ui/blob/main/.github/CONTRIBUTING.md) to get started.
 
 
 ## 📄 License
@@ -156,4 +164,4 @@ Apache License 2.0 © [The MCP UI Authors](LICENSE)
 
 ## Disclaimer
 
-This project is provided “as is”, without warranty of any kind. The `mcp-ui` authors and contributors shall not be held liable for any damages, losses, or issues arising from the use of this software. Use at your own risk.
+This project is provided "as is", without warranty of any kind. The `mcp-ui` authors and contributors shall not be held liable for any damages, losses, or issues arising from the use of this software. Use at your own risk.

--- a/examples/server/src/index.ts
+++ b/examples/server/src/index.ts
@@ -155,7 +155,7 @@ export class MyMCP extends McpAgent {
 
         // Generate a unique URI for this specific invocation of the file picker UI.
         // This URI identifies the resource block itself, not the content of the iframe.
-        const uniqueUiAppUri = `ui-app://task-manager/${Date.now()}`;
+        const uniqueUiAppUri = `ui://task-manager/${Date.now()}`;
         const resourceBlock = createHtmlResource({
           uri: uniqueUiAppUri,
           content: { type: 'externalUrl', iframeUrl: pickerPageUrl },
@@ -181,7 +181,7 @@ export class MyMCP extends McpAgent {
 
         // Generate a unique URI for this specific invocation of the file picker UI.
         // This URI identifies the resource block itself, not the content of the iframe.
-        const uniqueUiAppUri = `ui-app://user-profile/${Date.now()}`;
+        const uniqueUiAppUri = `ui://user-profile/${Date.now()}`;
         const resourceBlock = createHtmlResource({
           uri: uniqueUiAppUri,
           content: { type: 'externalUrl', iframeUrl: pickerPageUrl },

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -44,8 +44,8 @@ The primary payload exchanged between the server and the client:
 interface HtmlResourceBlock {
   type: 'resource';
   resource: {
-    uri: string;       // e.g. "ui://component/id" or "ui-app://app/instance"
-    mimeType: 'text/html';
+    uri: string;       // e.g. "ui://component/id"
+    mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content, text/uri-list for URL content
     text?: string;      // Inline HTML or external URL
     blob?: string;      // Base64-encoded HTML or URL (for large payloads)
   };
@@ -53,9 +53,9 @@ interface HtmlResourceBlock {
 ```
 
 * **`uri`**: Unique identifier for caching and routing
-  * `ui://…` — self-contained HTML (rendered via `<iframe srcDoc>`)
-  * `ui-app://…` — external app/site (rendered via `<iframe src>`)
-* **`mimeType`**: Always `text/html`
+  * `ui://…` — UI resources (rendering method determined by mimeType)
+* **`mimeType`**: `text/html` for HTML content (iframe srcDoc), `text/uri-list` for URL content (iframe src)
+  * **MCP-UI requires a single URL**: While `text/uri-list` format supports multiple URLs, MCP-UI uses only the first valid URL and logs others
 * **`text` vs. `blob`**: Choose `text` for simple strings; use `blob` for larger or encoded content.
 
 It's rendered in the client with the `<HtmlResource>` React component.
@@ -95,7 +95,7 @@ yarn add @mcp-ui/server @mcp-ui/client
 
    // External URL
    const external = createHtmlResource({
-     uri: 'ui-app://widget/session-42',
+     uri: 'ui://widget/session-42',
      content: { type: 'externalUrl', iframeUrl: 'https://example.com/widget' },
      delivery: 'text',
    });
@@ -110,7 +110,7 @@ yarn add @mcp-ui/server @mcp-ui/client
    function App({ mcpResource }) {
      if (
        mcpResource.type === 'resource' &&
-       mcpResource.resource.mimeType === 'text/html'
+       mcpResource.resource.uri?.startsWith('ui://')
      ) {
        return (
          <HtmlResource
@@ -146,14 +146,16 @@ Drop those URLs into any MCP-compatible host to see `mcp-ui` in action.
 
 ## 🛣️ Roadmap
 
-- [ ] Support new SSR methods (e.g., RSC)
-- [ ] Support additional client-side libraries
-- [ ] Expand UI Action API
+- [X] Add online playground
+- [ ] Support React Server Components
+- [ ] Support Remote-DOM
+- [ ] Support additional client-side libraries (e.g., Vue)
+- [ ] Expand UI Action API (beyond tool calls)
 - [ ] Do more with Resources and Sampling
 
 ## 🤝 Contributing
 
-Contributions, ideas, and bug reports are welcome! See the [contribution guidelines](https://github.com/idosal/mco-ui/blob/main/.github/CONTRIBUTING.md) to get started.
+Contributions, ideas, and bug reports are welcome! See the [contribution guidelines](https://github.com/idosal/mcp-ui/blob/main/.github/CONTRIBUTING.md) to get started.
 
 
 ## 📄 License
@@ -162,4 +164,4 @@ Apache License 2.0 © [The MCP UI Authors](LICENSE)
 
 ## Disclaimer
 
-This project is provided “as is”, without warranty of any kind. The `mcp-ui` authors and contributors shall not be held liable for any damages, losses, or issues arising from the use of this software. Use at your own risk.
+This project is provided "as is", without warranty of any kind. The `mcp-ui` authors and contributors shall not be held liable for any damages, losses, or issues arising from the use of this software. Use at your own risk.

--- a/packages/client/src/components/HtmlResource.tsx
+++ b/packages/client/src/components/HtmlResource.tsx
@@ -32,41 +32,63 @@ export const HtmlResource: React.FC<RenderHtmlResourceProps> = ({
       setIframeSrc(null);
       setIframeRenderMode('srcDoc'); // Default to srcDoc
 
-      if (resource.mimeType !== 'text/html') {
-        setError('Resource is not of type text/html.');
+      if (resource.mimeType !== 'text/html' && resource.mimeType !== 'text/uri-list') {
+        setError('Resource must be of type text/html (for HTML content) or text/uri-list (for URL content).');
         setIsLoading(false);
         return;
       }
 
-      if (resource.uri?.startsWith('ui-app://')) {
+      if (resource.mimeType === 'text/uri-list') {
+        // Handle URL content (external apps)
+        // Note: While text/uri-list format supports multiple URLs, MCP-UI requires a single URL.
+        // If multiple URLs are provided, only the first will be used and others will be logged as warnings.
         setIframeRenderMode('src');
+        let urlContent = '';
+        
         if (typeof resource.text === 'string' && resource.text.trim() !== '') {
-          setIframeSrc(resource.text);
+          urlContent = resource.text;
         } else if (typeof resource.blob === 'string') {
           try {
-            const decodedUrl = new TextDecoder().decode(
+            urlContent = new TextDecoder().decode(
               Uint8Array.from(atob(resource.blob), (c) => c.charCodeAt(0)),
             );
-            if (decodedUrl.trim() !== '') {
-              setIframeSrc(decodedUrl);
-            } else {
-              setError('Decoded blob for ui-app:// URL is empty.');
-            }
           } catch (e) {
-            console.error('Error decoding base64 blob for ui-app URL:', e);
-            setError('Error decoding URL from blob for ui-app://.');
+            console.error('Error decoding base64 blob for URL content:', e);
+            setError('Error decoding URL from blob.');
+            setIsLoading(false);
+            return;
           }
         } else {
           setError(
-            'ui-app:// resource expects a non-empty text or blob field containing the URL.',
+            'URL resource expects a non-empty text or blob field containing the URL.',
           );
+          setIsLoading(false);
+          return;
         }
-      } else if (
-        resource.uri?.startsWith('ui://') ||
-        (!resource.uri &&
-          (typeof resource.text === 'string' ||
-            typeof resource.blob === 'string'))
-      ) {
+
+        if (urlContent.trim() === '') {
+          setError('URL content is empty.');
+          setIsLoading(false);
+          return;
+        }
+
+        // Parse uri-list format: URIs separated by newlines, comments start with #
+        // MCP-UI requires a single URL - if multiple are found, use first and warn about others
+        const lines = urlContent.split('\n').map(line => line.trim()).filter(line => line && !line.startsWith('#'));
+        
+        if (lines.length === 0) {
+          setError('No valid URLs found in uri-list content.');
+          setIsLoading(false);
+          return;
+        }
+
+        if (lines.length > 1) {
+          console.warn(`Multiple URLs found in uri-list content. Using the first URL: "${lines[0]}". Other URLs ignored:`, lines.slice(1));
+        }
+
+        setIframeSrc(lines[0]);
+      } else if (resource.mimeType === 'text/html') {
+        // Handle HTML content
         setIframeRenderMode('srcDoc');
         if (typeof resource.text === 'string') {
           setHtmlString(resource.text);
@@ -80,15 +102,12 @@ export const HtmlResource: React.FC<RenderHtmlResourceProps> = ({
             console.error('Error decoding base64 blob for HTML content:', e);
             setError('Error decoding HTML content from blob.');
           }
-        } else if (resource.uri?.startsWith('ui://')) {
-          // This case implies uri is 'ui://' but no text AND no blob.
-          setError('ui:// HTML resource requires text or blob content.');
+        } else {
+          setError('HTML resource requires text or blob content.');
         }
-        // If !resource.uri, the outer condition ensures text or blob is present.
       } else {
-        // MimeType is text/html, but no uri, or URI schema not handled, and no direct text/blob.
         setError(
-          'HTML resource has no suitable content (text, blob, or interpretable URI).',
+          'Unsupported mimeType. Expected text/html or text/uri-list.',
         );
       }
       setIsLoading(false);

--- a/packages/client/src/components/__tests__/HtmlResource.test.tsx
+++ b/packages/client/src/components/__tests__/HtmlResource.test.tsx
@@ -169,6 +169,50 @@ https://example.com/backup
     render(<HtmlResource {...props} />);
     expect(screen.getByText('No valid URLs found in uri-list content.')).toBeInTheDocument();
   });
+
+  it('supports backwards compatibility with ui-app:// URI scheme', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const props: RenderHtmlResourceProps = {
+      resource: {
+        uri: 'ui-app://legacy-external-app',
+        mimeType: 'text/html', // Historically incorrect mimeType, but should be treated as URL content
+        text: 'https://legacy.example.com/app',
+      },
+      onUiAction: mockOnUiAction,
+    };
+    render(<HtmlResource {...props} />);
+    const iframe = screen.getByTitle(
+      'MCP HTML Resource (URL)',
+    ) as HTMLIFrameElement;
+    expect(iframe.src).toBe('https://legacy.example.com/app');
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Detected legacy ui-app:// URI: "ui-app://legacy-external-app". Update server to use ui:// with mimeType: \'text/uri-list\' for future compatibility.'
+    );
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('handles legacy ui-app:// with blob content', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const url = 'https://legacy.example.com/blob-app';
+    const encodedUrl = Buffer.from(url).toString('base64');
+    const props: RenderHtmlResourceProps = {
+      resource: {
+        uri: 'ui-app://legacy-blob-app',
+        mimeType: 'text/html', // Historically incorrect mimeType
+        blob: encodedUrl,
+      },
+      onUiAction: mockOnUiAction,
+    };
+    render(<HtmlResource {...props} />);
+    const iframe = screen.getByTitle(
+      'MCP HTML Resource (URL)',
+    ) as HTMLIFrameElement;
+    expect(iframe.src).toBe(url);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Detected legacy ui-app:// URI: "ui-app://legacy-blob-app". Update server to use ui:// with mimeType: \'text/uri-list\' for future compatibility.'
+    );
+    consoleWarnSpy.mockRestore();
+  });
 });
 
 const mockResourceBaseForUiActionTests: Partial<Resource> = {

--- a/packages/client/src/components/__tests__/HtmlResource.test.tsx
+++ b/packages/client/src/components/__tests__/HtmlResource.test.tsx
@@ -25,11 +25,11 @@ describe('HtmlResource component', () => {
     expect(iframe.srcdoc).toContain('<p>Hello Test</p>');
   });
 
-  it('renders iframe with src for ui-app:// URI with text', () => {
+  it('renders iframe with src for ui:// URI with text', () => {
     const props: RenderHtmlResourceProps = {
       resource: {
-        uri: 'ui-app://my-app',
-        mimeType: 'text/html',
+        uri: 'ui://my-app',
+        mimeType: 'text/uri-list',
         text: 'https://example.com/app',
       },
       onUiAction: mockOnUiAction,
@@ -58,18 +58,18 @@ describe('HtmlResource component', () => {
     // This assertion depends heavily on the refined async logic of HtmlResource.
     // For now, let's expect the fallback paragraph because no content is provided.
     expect(
-      screen.getByText('ui:// HTML resource requires text or blob content.'),
+      screen.getByText('HTML resource requires text or blob content.'),
     ).toBeInTheDocument();
   });
 
-  it('displays an error message if resource mimeType is not text/html', () => {
+  it('displays an error message if resource mimeType is not text/html or text/uri-list', () => {
     const props: RenderHtmlResourceProps = {
       resource: { mimeType: 'application/json', text: '{}' },
       onUiAction: mockOnUiAction,
     };
     render(<HtmlResource {...props} />);
     expect(
-      screen.getByText('Resource is not of type text/html.'),
+      screen.getByText('Resource must be of type text/html (for HTML content) or text/uri-list (for URL content).'),
     ).toBeInTheDocument();
   });
 
@@ -91,13 +91,13 @@ describe('HtmlResource component', () => {
     expect(iframe.srcdoc).toContain(html);
   });
 
-  it('decodes URL from blob for ui-app:// resource', () => {
+  it('decodes URL from blob for ui:// resource with text/uri-list mimetype', () => {
     const url = 'https://example.com/blob-app';
     const encodedUrl = Buffer.from(url).toString('base64');
     const props: RenderHtmlResourceProps = {
       resource: {
-        uri: 'ui-app://blob-app-test',
-        mimeType: 'text/html',
+        uri: 'ui://blob-app-test',
+        mimeType: 'text/uri-list',
         blob: encodedUrl,
       },
       onUiAction: mockOnUiAction,
@@ -107,6 +107,67 @@ describe('HtmlResource component', () => {
       'MCP HTML Resource (URL)',
     ) as HTMLIFrameElement;
     expect(iframe.src).toBe(url);
+  });
+
+  it('handles multiple URLs in uri-list format and uses the first one', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const uriList = 'https://example.com/first\nhttps://example.com/second\nhttps://example.com/third';
+    const props: RenderHtmlResourceProps = {
+      resource: {
+        uri: 'ui://multi-url-test',
+        mimeType: 'text/uri-list',
+        text: uriList,
+      },
+      onUiAction: mockOnUiAction,
+    };
+    render(<HtmlResource {...props} />);
+    const iframe = screen.getByTitle(
+      'MCP HTML Resource (URL)',
+    ) as HTMLIFrameElement;
+    expect(iframe.src).toBe('https://example.com/first');
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Multiple URLs found in uri-list content. Using the first URL: "https://example.com/first". Other URLs ignored:',
+      ['https://example.com/second', 'https://example.com/third']
+    );
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('handles uri-list format with comments and empty lines', () => {
+    const uriList = `# This is a comment
+https://example.com/main
+
+# Another comment
+https://example.com/backup
+`;
+    const props: RenderHtmlResourceProps = {
+      resource: {
+        uri: 'ui://uri-list-with-comments',
+        mimeType: 'text/uri-list',
+        text: uriList,
+      },
+      onUiAction: mockOnUiAction,
+    };
+    render(<HtmlResource {...props} />);
+    const iframe = screen.getByTitle(
+      'MCP HTML Resource (URL)',
+    ) as HTMLIFrameElement;
+    expect(iframe.src).toBe('https://example.com/main');
+  });
+
+  it('shows error when uri-list contains no valid URLs', () => {
+    const uriList = `# Only comments
+# No actual URLs
+`;
+    const props: RenderHtmlResourceProps = {
+      resource: {
+        uri: 'ui://empty-uri-list',
+        mimeType: 'text/uri-list',
+        text: uriList,
+      },
+      onUiAction: mockOnUiAction,
+    };
+    render(<HtmlResource {...props} />);
+    expect(screen.getByText('No valid URLs found in uri-list content.')).toBeInTheDocument();
   });
 });
 
@@ -264,7 +325,7 @@ describe('HtmlResource - onUiAction', () => {
     // Iframe should not be present
     expect(screen.queryByTitle('MCP HTML Resource (Embedded Content)')).not.toBeInTheDocument();
     // Error message should be displayed
-    expect(await screen.findByText('Resource is not of type text/html.')).toBeInTheDocument();
+    expect(await screen.findByText('Resource must be of type text/html (for HTML content) or text/uri-list (for URL content).')).toBeInTheDocument();
     
     const eventData = { tool: 'testTool', params: { foo: 'bar' } };
     dispatchMessage(window, eventData); 

--- a/packages/client/src/test-setup.ts
+++ b/packages/client/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'; 

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+  },
+}); 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -44,10 +44,10 @@ The primary payload exchanged between the server and the client:
 interface HtmlResourceBlock {
   type: 'resource';
   resource: {
-    uri: string;       // e.g. "ui://component/id"instance"
-    mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content (), text/uri-list for URL content
+    uri: string;       // e.g. "ui://component/id"
+    mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content, text/uri-list for URL content
     text?: string;      // Inline HTML or external URL
-    blob?: string;      // Base64-encoded HTML or URL (for large payloads)
+    blob?: string;      // Base64-encoded HTML or URL
   };
 }
 ```

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -44,8 +44,8 @@ The primary payload exchanged between the server and the client:
 interface HtmlResourceBlock {
   type: 'resource';
   resource: {
-    uri: string;       // e.g. "ui://component/id" or "ui-app://app/instance"
-    mimeType: 'text/html';
+    uri: string;       // e.g. "ui://component/id"instance"
+    mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content (), text/uri-list for URL content
     text?: string;      // Inline HTML or external URL
     blob?: string;      // Base64-encoded HTML or URL (for large payloads)
   };
@@ -53,9 +53,9 @@ interface HtmlResourceBlock {
 ```
 
 * **`uri`**: Unique identifier for caching and routing
-  * `ui://…` — self-contained HTML (rendered via `<iframe srcDoc>`)
-  * `ui-app://…` — external app/site (rendered via `<iframe src>`)
-* **`mimeType`**: Always `text/html`
+  * `ui://…` — UI resources (rendering method determined by mimeType)
+* **`mimeType`**: `text/html` for HTML content (iframe srcDoc), `text/uri-list` for URL content (iframe src)
+  * **MCP-UI requires a single URL**: While `text/uri-list` format supports multiple URLs, MCP-UI uses only the first valid URL and logs others
 * **`text` vs. `blob`**: Choose `text` for simple strings; use `blob` for larger or encoded content.
 
 It's rendered in the client with the `<HtmlResource>` React component.
@@ -95,7 +95,7 @@ yarn add @mcp-ui/server @mcp-ui/client
 
    // External URL
    const external = createHtmlResource({
-     uri: 'ui-app://widget/session-42',
+     uri: 'ui://widget/session-42',
      content: { type: 'externalUrl', iframeUrl: 'https://example.com/widget' },
      delivery: 'text',
    });
@@ -110,7 +110,7 @@ yarn add @mcp-ui/server @mcp-ui/client
    function App({ mcpResource }) {
      if (
        mcpResource.type === 'resource' &&
-       mcpResource.resource.mimeType === 'text/html'
+       mcpResource.resource.uri?.startsWith('ui://')
      ) {
        return (
          <HtmlResource
@@ -162,4 +162,4 @@ Apache License 2.0 © [The MCP UI Authors](LICENSE)
 
 ## Disclaimer
 
-This project is provided “as is”, without warranty of any kind. The `mcp-ui` authors and contributors shall not be held liable for any damages, losses, or issues arising from the use of this software. Use at your own risk.
+This project is provided "as is", without warranty of any kind. The `mcp-ui` authors and contributors shall not be held liable for any damages, losses, or issues arising from the use of this software. Use at your own risk.

--- a/packages/server/src/__tests__/index.test.ts
+++ b/packages/server/src/__tests__/index.test.ts
@@ -31,7 +31,7 @@ describe('@mcp-ui/server', () => {
 
     it('should create a text-based external URL resource', () => {
       const options = {
-        uri: 'ui-app://test-url',
+        uri: 'ui://test-url',
         content: {
           type: 'externalUrl' as const,
           iframeUrl: 'https://example.com',
@@ -39,14 +39,15 @@ describe('@mcp-ui/server', () => {
         delivery: 'text' as const,
       };
       const resource = createHtmlResource(options);
-      expect(resource.resource.uri).toBe('ui-app://test-url');
+      expect(resource.resource.uri).toBe('ui://test-url');
+      expect(resource.resource.mimeType).toBe('text/uri-list');
       expect(resource.resource.text).toBe('https://example.com');
       expect(resource.resource.blob).toBeUndefined();
     });
 
     it('should create a blob-based external URL resource', () => {
       const options = {
-        uri: 'ui-app://test-url-blob',
+        uri: 'ui://test-url-blob',
         content: {
           type: 'externalUrl' as const,
           iframeUrl: 'https://example.com/blob',
@@ -54,8 +55,23 @@ describe('@mcp-ui/server', () => {
         delivery: 'blob' as const,
       };
       const resource = createHtmlResource(options);
+      expect(resource.resource.mimeType).toBe('text/uri-list');
       expect(resource.resource.blob).toBe(
         Buffer.from('https://example.com/blob').toString('base64'),
+      );
+      expect(resource.resource.text).toBeUndefined();
+    });
+
+    it('should create a blob-based direct HTML resource with correct mimetype', () => {
+      const options = {
+        uri: 'ui://test-html-blob',
+        content: { type: 'rawHtml' as const, htmlString: '<h1>Blob</h1>' },
+        delivery: 'blob' as const,
+      };
+      const resource = createHtmlResource(options);
+      expect(resource.resource.mimeType).toBe('text/html');
+      expect(resource.resource.blob).toBe(
+        Buffer.from('<h1>Blob</h1>').toString('base64'),
       );
       expect(resource.resource.text).toBeUndefined();
     });
@@ -81,7 +97,7 @@ describe('@mcp-ui/server', () => {
         delivery: 'text' as const,
       };
       expect(() => createHtmlResource(options)).toThrow(
-        "MCP SDK: URI must start with 'ui-app://' when content.type is 'externalUrl'.",
+        "MCP SDK: URI must start with 'ui://' when content.type is 'externalUrl'.",
       );
     });
   });

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+}); 


### PR DESCRIPTION
Consolidate all render formats under `ui://`. The sentiment from the community is that we should use mimeType to discriminate between types. Currently, `mcp-ui` still supports raw HTML (`text/html`) and external URL (`text/uri-list`), but in the future we'll be able to add arbitrary types in the future.

This PR maintains backwards compatibility on the client side with proper warnings. Support will be removed in MAJOR version 4.