### PR TITLE
fix: typescript types to be compatible with MCP SDK

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -121,8 +121,10 @@ export function createHtmlResource(
       break;
     default:
       // Exhaustive check
-      const exhaustiveCheck: never = options.delivery;
-      throw new Error(`Invalid delivery type: ${exhaustiveCheck}`);
+      (() => {
+        const exhaustiveCheck: never = options.delivery;
+        throw new Error(`Invalid delivery type: ${exhaustiveCheck}`);
+      })();
   }
 
   return {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,13 +8,13 @@ import {
   Base64BlobContent,
   CreateHtmlResourceOptions,
   HtmlTextContent,
-  mimeType,
+  MimeType,
   UiActionResult,
   UiActionResultLink,
   UiActionResultNotification,
   UiActionResultPrompt,
   UiActionResultIntent,
-  UiActionResultToolCall
+  UiActionResultToolCall,
 } from './types.js';
 
 export type HtmlResourceBlock = {
@@ -66,7 +66,7 @@ export function createHtmlResource(
   options: CreateHtmlResourceOptions,
 ): HtmlResourceBlock {
   let actualContentString: string;
-  let mimeType: mimeType;
+  let mimeType: MimeType;
 
   if (options.content.type === 'rawHtml') {
     if (!options.uri.startsWith('ui://')) {
@@ -173,9 +173,7 @@ export function uiActionResultToolCall(
   };
 }
 
-export function uiActionResultPrompt(
-  prompt: string,
-): UiActionResultPrompt {
+export function uiActionResultPrompt(prompt: string): UiActionResultPrompt {
   return {
     type: 'prompt',
     payload: {
@@ -209,7 +207,7 @@ export function uiActionResultIntent(
 export function uiActionResultNotification(
   message: string,
 ): UiActionResultNotification {
-  return {  
+  return {
     type: 'notification',
     payload: {
       message,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,17 +4,17 @@
  */
 
 // Import types first
-import { CreateHtmlResourceOptions } from './types.js';
+import {
+  Base64BlobContent,
+  CreateHtmlResourceOptions,
+  HtmlTextContent,
+  mimeType,
+} from './types.js';
 
-export interface HtmlResourceBlock {
+export type HtmlResourceBlock = {
   type: 'resource';
-  resource: {
-    uri: string; // Primary identifier. Starts with "ui://"
-    mimeType: 'text/html' | 'text/uri-list'; // text/html for rawHtml content, text/uri-list for externalUrl content
-    text?: string; // HTML content (for mimeType `text/html`), or iframe URL (for mimeType `text/uri-list`)
-    blob?: string; // Base64 encoded HTML content (for mimeType `text/html`), or iframe URL (for mimeType `text/uri-list`)
-  };
-}
+  resource: HtmlTextContent | Base64BlobContent;
+};
 
 /**
  * Robustly encodes a UTF-8 string to Base64.
@@ -60,7 +60,7 @@ export function createHtmlResource(
   options: CreateHtmlResourceOptions,
 ): HtmlResourceBlock {
   let actualContentString: string;
-  let mimeType: 'text/html' | 'text/uri-list';
+  let mimeType: mimeType;
 
   if (options.content.type === 'rawHtml') {
     if (!options.uri.startsWith('ui://')) {
@@ -96,18 +96,27 @@ export function createHtmlResource(
     );
   }
 
-  const resource: HtmlResourceBlock['resource'] = {
-    uri: options.uri,
-    mimeType: mimeType,
-  };
+  let resource: HtmlResourceBlock['resource'];
 
   switch (options.delivery) {
     case 'text':
-      resource.text = actualContentString;
+      resource = {
+        uri: options.uri,
+        mimeType: mimeType,
+        text: actualContentString,
+      };
       break;
     case 'blob':
-      resource.blob = robustUtf8ToBase64(actualContentString);
+      resource = {
+        uri: options.uri,
+        mimeType: mimeType,
+        blob: robustUtf8ToBase64(actualContentString),
+      };
       break;
+    default:
+      // Exhaustive check
+      const exhaustiveCheck: never = options.delivery;
+      throw new Error(`Invalid delivery type: ${exhaustiveCheck}`);
   }
 
   return {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,9 +1,29 @@
+// Primary identifier for the resource. Starts with ui://`
+export type URI = `ui://${string}`;
+
+// text/html for rawHtml content, text/uri-list for externalUrl content
+export type mimeType = 'text/html' | 'text/uri-list';
+
+export type HtmlTextContent = {
+  uri: URI;
+  mimeType: mimeType;
+  text: string; // HTML content (for mimeType `text/html`), or iframe URL (for mimeType `text/uri-list`)
+  blob?: never;
+};
+
+export type Base64BlobContent = {
+  uri: URI;
+  mimeType: mimeType;
+  blob: string; //  Base64 encoded HTML content (for mimeType `text/html`), or iframe URL (for mimeType `text/uri-list`)
+  text?: never;
+};
+
 export type ResourceContentPayload =
   | { type: 'rawHtml'; htmlString: string }
   | { type: 'externalUrl'; iframeUrl: string };
 
 export interface CreateHtmlResourceOptions {
-  uri: string; // REQUIRED. Must start with "ui://" if content.type is "rawHtml",
+  uri: URI; // REQUIRED. Must start with "ui://" if content.type is "rawHtml",
   // or "ui-app://" if content.type is "externalUrl".
   content: ResourceContentPayload; // REQUIRED. The actual content payload.
   delivery: 'text' | 'blob'; // REQUIRED. How the content string (htmlString or iframeUrl) should be packaged.

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -2,18 +2,18 @@
 export type URI = `ui://${string}`;
 
 // text/html for rawHtml content, text/uri-list for externalUrl content
-export type mimeType = 'text/html' | 'text/uri-list';
+export type MimeType = 'text/html' | 'text/uri-list';
 
 export type HtmlTextContent = {
   uri: URI;
-  mimeType: mimeType;
+  mimeType: MimeType;
   text: string; // HTML content (for mimeType `text/html`), or iframe URL (for mimeType `text/uri-list`)
   blob?: never;
 };
 
 export type Base64BlobContent = {
   uri: URI;
-  mimeType: mimeType;
+  mimeType: MimeType;
   blob: string; //  Base64 encoded HTML content (for mimeType `text/html`), or iframe URL (for mimeType `text/uri-list`)
   text?: never;
 };
@@ -29,7 +29,12 @@ export interface CreateHtmlResourceOptions {
   delivery: 'text' | 'blob'; // REQUIRED. How the content string (htmlString or iframeUrl) should be packaged.
 }
 
-export type UiActionType = 'tool' | 'prompt' | 'link' | 'intent' | 'notification';
+export type UiActionType =
+  | 'tool'
+  | 'prompt'
+  | 'link'
+  | 'intent'
+  | 'notification';
 
 export type UiActionResultToolCall = {
   type: 'tool';


### PR DESCRIPTION
Hi folks! Please let me know if you'd like me to make any adjustments or if you need more info. 

This PR proposes a discriminated union type to meet type expectations when creating an MCP server with the [MCP typescript SDK](https://github.com/modelcontextprotocol/typescript-sdk).

Here's the error I got when I returned an object created by `createHtmlResource()` from the SDK's `McpServer`:
```
No overload matches this call.
  Overload 1 of 6, '(name: string, description: string, paramsSchemaOrAnnotations: { [x: string]: unknown; title?: string | undefined; readOnlyHint?: boolean | undefined; destructiveHint?: boolean | undefined; idempotentHint?: boolean | undefined; openWorldHint?: boolean | undefined; } | {}, cb: (args: {}, extra: RequestHandlerExtra<...>) => { ...; } | Promise<...>): RegisteredTool', gave the following error.
    Argument of type '() => Promise<{ content: HtmlResourceBlock[]; }>' is not assignable to parameter of type '(args: {}, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => { [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { ...; } | { ...; } | { ...; })[]; _meta?: { ...; } | undefined; structuredContent?: { ...; } | undefined; isError?: boolean | undefined; } | Promise<...'.
      Type 'Promise<{ content: HtmlResourceBlock[]; }>' is not assignable to type '{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { ...; })[]; _meta?: { ...; } | undefined; structuredContent?: { ...; } | und...'.
        Type 'Promise<{ content: HtmlResourceBlock[]; }>' is not assignable to type 'Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { ...; })[]; _meta?: { ...; } | undefined; structuredContent?: { ...;...'.
          Type '{ content: HtmlResourceBlock[]; }' is not assignable to type '{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { ...; })[]; _meta?: { ...; } | undefined; structuredContent?: { ...; } | und...'.
            Types of property 'content' are incompatible.
              Type 'HtmlResourceBlock[]' is not assignable to type '({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: { ...; } | { ...; }; })[]'.
                Type 'HtmlResourceBlock' is not assignable to type '{ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: { ...; } | { ...; }; }'.
                  Type 'HtmlResourceBlock' is not assignable to type '{ [x: string]: unknown; type: "resource"; resource: { [x: string]: unknown; text: string; uri: string; mimeType?: string | undefined; } | { [x: string]: unknown; uri: string; blob: string; mimeType?: string | undefined; }; }'.
                    Types of property 'resource' are incompatible.
                      Type '{ uri: string; mimeType: "text/html" | "text/uri-list"; text?: string | undefined; blob?: string | undefined; }' is not assignable to type '{ [x: string]: unknown; text: string; uri: string; mimeType?: string | undefined; } | { [x: string]: unknown; uri: string; blob: string; mimeType?: string | undefined; }'.
                        Type '{ uri: string; mimeType: "text/html" | "text/uri-list"; text?: string | undefined; blob?: string | undefined; }' is not assignable to type '{ [x: string]: unknown; uri: string; blob: string; mimeType?: string | undefined; }'.
                          Types of property 'blob' are incompatible.
                            Type 'string | undefined' is not assignable to type 'string'.
                              Type 'undefined' is not assignable to type 'string'.
  Overload 2 of 6, '(name: string, paramsSchema: ZodRawShape, annotations: { [x: string]: unknown; title?: string | undefined; readOnlyHint?: boolean | undefined; destructiveHint?: boolean | undefined; idempotentHint?: boolean | undefined; openWorldHint?: boolean | undefined; }, cb: (args: { ...; }, extra: RequestHandlerExtra<...>) => { ...; } | Promise<...>): RegisteredTool', gave the following error.
    Argument of type 'string' is not assignable to parameter of type 'ZodRawShape'.
```