### PR TITLE
fix: rename Html to UiSnippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 `mcp-ui` is a TypeScript SDK comprising two packages:
 
-* **`@mcp-ui/server`**: Utilities to generate UI snippets (`HtmlResourceBlock`) on your MCP server.
+* **`@mcp-ui/server`**: Utilities to generate UI snippets (`UiSnippetResource`) on your MCP server.
 * **`@mcp-ui/client`**: UI components (e.g., `<ResourceRenderer />`) to render those snippets and handle their events.
 
 Together, they let you define reusable UI snippets on the server side, seamlessly and securely render them in the client, and react to their actions in the MCP host environment.
@@ -44,11 +44,11 @@ Together, they let you define reusable UI snippets on the server side, seamlessl
 
 In essence, by using `mcp-ui` SDKs, servers and hosts can agree on contracts that enable them to create and render interactive UI snippets (as a path to a standardized UI approach in MCP).
 
-### HTML Resource Block
-The primary payload returned from the server to the client is the `HtmlResourceBlock`:
+### UI Snippet Resource
+The primary payload returned from the server to the client is the `UiSnippetResource`:
 
 ```ts
-interface HtmlResourceBlock {
+interface UiSnippetResource {
   type: 'resource';
   resource: {
     uri: string;       // ui://component/id
@@ -67,7 +67,7 @@ interface HtmlResourceBlock {
 
 ### Resource Renderer
 
-The HTML Resource Block is rendered in the `<ResourceRenderer />` component. It automatically detects the resource type and renders the appropriate component.
+The UI SnippetResource is rendered in the `<ResourceRenderer />` component. It automatically detects the resource type and renders the appropriate component.
 
 It accepts the following props:
 - **`resource`**: The resource object from an MCP response. Should include `uri`, `mimeType`, and content (`text`, `blob`, or `content`)
@@ -123,7 +123,7 @@ yarn add @mcp-ui/server @mcp-ui/client
 1. **Server-side**: Build your resource blocks
 
    ```ts
-   import { createHtmlResource } from '@mcp-ui/server';
+   import { createUiSnippetResource } from '@mcp-ui/server';
    import {
     createRemoteComponent,
     createRemoteDocument,
@@ -131,14 +131,14 @@ yarn add @mcp-ui/server @mcp-ui/client
    } from '@remote-dom/core';
 
    // Inline HTML
-   const htmlResource = createHtmlResource({
+   const htmlResource = createUiSnippetResource({
      uri: 'ui://greeting/1',
      content: { type: 'rawHtml', htmlString: '<p>Hello, MCP UI!</p>' },
      delivery: 'text',
    });
 
    // External URL
-   const externalUrlResource = createHtmlResource({
+   const externalUrlResource = createUiSnippetResource({
      uri: 'ui://greeting/1',
      content: { type: 'externalUrl', iframeUrl: 'https://example.com' },
      delivery: 'text',
@@ -199,6 +199,7 @@ Host and user security is one of `mcp-ui`'s primary concerns. In all content typ
 - [X] Support Web Components
 - [X] Support Remote-DOM
 - [ ] Add component libraries (in progress)
+- [ ] Support additional frontend frameworks
 - [ ] Add declarative UI content type
 - [ ] Support generative UI?
       

--- a/docs/src/.vitepress/config.ts
+++ b/docs/src/.vitepress/config.ts
@@ -85,13 +85,6 @@ export default defineConfig({
             { text: 'Usage & Examples', link: '/guide/client/usage-examples' },
           ],
         },
-        {
-          text: 'Shared SDK',
-          collapsed: false,
-          items: [
-            { text: 'Overview', link: '/guide/shared/overview' },
-          ],
-        },
       ],
     },
 

--- a/docs/src/guide/client/html-resource.md
+++ b/docs/src/guide/client/html-resource.md
@@ -17,7 +17,7 @@ export interface HtmlResourceProps {
 
 The component accepts the following props:
 
-- **`resource`**: The resource object from an `HtmlResourceBlock`. It should include `uri`, `mimeType`, and either `text` or `blob`.
+- **`resource`**: The resource object from an `UiSnippetResource`. It should include `uri`, `mimeType`, and either `text` or `blob`.
 - **`onUiAction`**: An optional callback that fires when the iframe content (for `ui://` resources) posts a message to your app. The message should look like:
   ```typescript
   { type: 'tool', payload: { toolName: string, params: Record<string, unknown> } } |

--- a/docs/src/guide/client/usage-examples.md
+++ b/docs/src/guide/client/usage-examples.md
@@ -16,8 +16,8 @@ npm i @mcp-ui/client
 import React, { useState } from 'react';
 import { ResourceRenderer, UiActionResult } from '@mcp-ui/client';
 
-// Simulate fetching an MCP resource block
-const fetchMcpResource = async (id: string): Promise<HtmlResource> => {
+// Simulate fetching an MCP UI snippet
+const fetchMcpResource = async (id: string): Promise<UiSnippetResource> => {
   if (id === 'direct') {
     return {
       type: 'resource',
@@ -52,7 +52,7 @@ const fetchMcpResource = async (id: string): Promise<HtmlResource> => {
 };
 
 const App: React.FC = () => {
-  const [resourceBlock, setResourceBlock] = useState<HtmlResource | null>(
+  const [resourceBlock, setResourceBlock] = useState<UiSnippetResource | null>(
     null,
   );
   const [loading, setLoading] = useState(false);

--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -55,11 +55,11 @@ Once built, you can typically import from the packages as you would with any oth
 
 ```typescript
 // main.ts (your server-side application)
-import { createHtmlResource } from '@mcp-ui/server';
+import { createUiSnippetResource } from '@mcp-ui/server';
 
 const myHtmlPayload = `<h1>Hello from Server!</h1><p>Timestamp: ${new Date().toISOString()}</p>`;
 
-const resourceBlock = createHtmlResource({
+const resourceBlock = createUiSnippetResource({
   uri: 'ui://server-generated/item1',
   content: { type: 'rawHtml', htmlString: myHtmlPayload },
   delivery: 'text',
@@ -78,7 +78,7 @@ import { ResourceRenderer, UiActionResult } from '@mcp-ui/client';
 
 // Dummy MCP response structure
 interface McpToolResponse {
-  content: HtmlResource[];
+  content: any[];
 }
 
 function App() {
@@ -182,8 +182,8 @@ npm i @mcp-ui/client
 ## Key Components
 
 ### Server Side (`@mcp-ui/server`)
-- **`createHtmlResource`**: Creates HTML resource objects for MCP responses
-- Handles HTML content, external URLs, and encoding options
+- **`createUiSnippetResource`**: Creates UI Snippet resource objects for MCP tool responses
+- Handles HTML content, external URLs, Remote DOM JS, and encoding options
 
 ### Client Side (`@mcp-ui/client`)
 - **`<ResourceRenderer />`**: Main component for rendering all types of MCP-UI resources

--- a/docs/src/guide/introduction.md
+++ b/docs/src/guide/introduction.md
@@ -8,23 +8,23 @@ This SDK provides tools for building Model Context Protocol (MCP) enabled applic
 
 MCP-UI is a TypeScript SDK containing:
 
-- **`@mcp-ui/client`**: UI components (like `<ResourceRenderer />`) for easy rendering of interactive HTML resources.
-- **`@mcp-ui/server`**: Helper functions (like `createHtmlResource`) for server-side logic to easily construct `HtmlResource` objects.
+- **`@mcp-ui/client`**: UI components (like `<ResourceRenderer />`) for easy rendering of interactive UI snippets.
+- **`@mcp-ui/server`**: Helper functions (like `createUiSnippetResource`) for server-side logic to easily construct `UiSnippetResource` objects.
 
-## Core Concept: The Interactive HTML Resource Protocol
+## Core Concept: The Interactive UI Snippet Resource Protocol
 
-The central piece of this SDK is the `HtmlResource`. This object defines a contract for how interactive HTML content should be structured and delivered from a server/tool to a client.
+The central piece of this SDK is the `UiSnippetResource`. This object defines a contract for how interactive UI snippet should be structured and delivered from a server/tool to a client.
 
-### `HtmlResource` Structure
+### `UiSnippetResource` Structure
 
 ```typescript
-export interface HtmlResource {
-  type: 'resource'; // Fixed type identifier
+interface UiSnippetResource {
+  type: 'resource';
   resource: {
-    uri: string; // Unique identifier. Governs rendering behavior.
-    mimeType: 'text/html' | 'text/uri-list'; // text/html for HTML content, text/uri-list for URL content
-    text?: string; // Raw HTML string or an iframe URL string.
-    blob?: string; // Base64 encoded HTML string or iframe URL string.
+    uri: string;       // ui://component/id
+    mimeType: 'text/html' | 'text/uri-list' | 'application/vnd.mcp-ui.remote-dom'; // text/html for HTML content, text/uri-list for URL content, application/vnd.mcp-ui.remote-dom for remote-dom content (Javascript)
+    text?: string;      // Inline HTML or external URL
+    blob?: string;      // Base64-encoded HTML or URL
   };
 }
 ```
@@ -48,9 +48,9 @@ export interface HtmlResource {
 
 **Server (MCP Tool):**
 ```typescript
-import { createHtmlResource } from '@mcp-ui/server';
+import { createUiSnippetResource } from '@mcp-ui/server';
 
-const resource = createHtmlResource({
+const resource = createUiSnippetResource({
   uri: 'ui://my-tool/dashboard',
   content: { type: 'rawHtml', htmlString: '<h1>Dashboard</h1>' },
   delivery: 'text'

--- a/docs/src/guide/protocol-details.md
+++ b/docs/src/guide/protocol-details.md
@@ -1,15 +1,15 @@
 # Protocol Details
 
-This section dives deeper into the `HtmlResourceBlock` and its intended usage.
+This section dives deeper into the `UiSnippetResource` and its intended usage.
 
-## `HtmlResourceBlock` Recap
+## `UiSnippetResource` Recap
 
 ```typescript
-export interface HtmlResourceBlock {
+export interface UiSnippetResource {
   type: 'resource';
   resource: {
     uri: string;
-    mimeType: 'text/html' | 'text/uri-list';
+    mimeType: 'text/html' | 'text/uri-list' | 'application/vnd.mcp-ui.remote-dom';
     text?: string;
     blob?: string;
   };

--- a/docs/src/guide/server/overview.md
+++ b/docs/src/guide/server/overview.md
@@ -1,15 +1,15 @@
 # @mcp-ui/server Overview
 
-The `@mcp-ui/server` package provides server-side utilities to help construct `HtmlResource` objects, which can then be sent to a client as part of an MCP response.
+The `@mcp-ui/server` package provides server-side utilities to help construct `UiSnippetResource` objects, which can then be sent to a client as part of an MCP response.
 
 ## Key Exports
 
-- **`createHtmlResource(options: CreateHtmlResourceOptions): HtmlResource`**:
-  The primary function for creating resource blocks. It takes an options object to define the URI, content (direct HTML or external URL), and delivery method (text or blob).
+- **`createUiSnippetResource(options: CreateUiSnippetResourceOptions): UiSnippetResource`**:
+  The primary function for creating UI snippets. It takes an options object to define the URI, content (direct HTML or external URL), and delivery method (text or blob).
 
 ## Purpose
 
-- **Ease of Use**: Simplifies the creation of valid `HtmlResource` objects.
+- **Ease of Use**: Simplifies the creation of valid `UiSnippetResource` objects.
 - **Validation**: Includes basic validation (e.g., URI prefixes matching content type).
 - **Encoding**: Handles Base64 encoding when `delivery: 'blob'` is specified.
 

--- a/docs/src/guide/server/usage-examples.md
+++ b/docs/src/guide/server/usage-examples.md
@@ -12,18 +12,18 @@ npm i @mcp-ui/server
 
 ## Basic Usage
 
-The core function is `createHtmlResource`.
+The core function is `createUiSnippetResource`.
 
 ```typescript
 import {
-  createHtmlResource,
+  createUiSnippetResource,
 } from '@mcp-ui/server';
 
 // Using a shared enum value (just for demonstration)
 console.log('Shared Enum from server usage:', PlaceholderEnum.FOO);
 
 // Example 1: Direct HTML, delivered as text
-const resource1 = createHtmlResource({
+const resource1 = createUiSnippetResource({
   uri: 'ui://my-component/instance-1',
   content: { type: 'rawHtml', htmlString: '<p>Hello World</p>' },
   delivery: 'text',
@@ -41,7 +41,7 @@ console.log('Resource 1:', JSON.stringify(resource1, null, 2));
 */
 
 // Example 2: Direct HTML, delivered as a Base64 blob
-const resource2 = createHtmlResource({
+const resource2 = createUiSnippetResource({
   uri: 'ui://my-component/instance-2',
   content: { type: 'rawHtml', htmlString: '<h1>Complex HTML</h1>' },
   delivery: 'blob',
@@ -63,7 +63,7 @@ console.log(
 
 // Example 3: External URL, text delivery
 const dashboardUrl = 'https://my.analytics.com/dashboard/123';
-const resource3 = createHtmlResource({
+const resource3 = createUiSnippetResource({
   uri: 'ui://analytics-dashboard/main',
   content: { type: 'externalUrl', iframeUrl: dashboardUrl },
   delivery: 'text',
@@ -82,7 +82,7 @@ console.log('Resource 3:', JSON.stringify(resource3, null, 2));
 
 // Example 4: External URL, blob delivery (URL is Base64 encoded)
 const chartApiUrl = 'https://charts.example.com/api?type=pie&data=1,2,3';
-const resource4 = createHtmlResource({
+const resource4 = createUiSnippetResource({
   uri: 'ui://live-chart/session-xyz',
   content: { type: 'externalUrl', iframeUrl: chartApiUrl },
   delivery: 'blob',
@@ -120,7 +120,7 @@ https://backup.dashboard.example.com/main
 # Emergency fallback (will be logged but not used)  
 https://emergency.dashboard.example.com/main`;
 
-const resource5 = createHtmlResource({
+const resource5 = createUiSnippetResource({
   uri: 'ui://dashboard-with-fallbacks/session-123',
   content: { type: 'externalUrl', iframeUrl: multiUrlContent },
   delivery: 'text',
@@ -135,14 +135,14 @@ const resource5 = createHtmlResource({
 
 ## Error Handling
 
-The `createHtmlResource` function will throw errors if invalid combinations are provided, for example:
+The `createUiSnippetResource` function will throw errors if invalid combinations are provided, for example:
 
 - URI not starting with `ui://` for any content type
 - Invalid content type specified
 
 ```typescript
 try {
-  createHtmlResource({
+  createUiSnippetResource({
     uri: 'invalid://should-be-ui',
     content: { type: 'externalUrl', iframeUrl: 'https://example.com' },
     delivery: 'text',

--- a/docs/src/guide/shared/overview.md
+++ b/docs/src/guide/shared/overview.md
@@ -1,7 +1,0 @@
-# @mcp-ui/shared Overview\n\nThe `@mcp-ui/shared` package is the foundation of the MCP-UI SDK, providing common types, enums, and utility functions used by both the server and client packages.\n\n## Key Exports\n\n- **`HtmlResourceBlock` (Interface)**: The core data structure for defining interactive HTML resources. (See [Protocol Details](../protocol-details.md) for more information).\n- **`ResourceContentPayload` (Type)**: Defines the structure for `content` within `CreateHtmlResourceOptions`, discriminating between direct HTML and external URLs.\n- **`CreateHtmlResourceOptions` (Interface)**: Options for the `createHtmlResource` function in `@mcp-ui/server`.\n- **`PlaceholderEnum` (Enum)**: An example enum: `export enum PlaceholderEnum { FOO = \'FOO\', BAR = \'BAR\' }`.\n- **`greet` (Function)**: An example utility function: `export const greet = (name: string): string => \`Hello, ${name}!\`;`\n\n## Purpose\n\n- **Consistency**: Ensures that client and server components operate on the same data structures.\n- **Reusability**: Offers common utilities that can be used across different parts of an MCP application.\n- **Type Safety**: Provides TypeScript definitions for better development experience.\n\n## Building\n\nThis package is built using Vite in library mode. It outputs ESM (`.mjs`) and UMD (`.js`) formats, along with TypeScript declaration files (`.d.ts`).\n\nTo build specifically this package from the monorepo root:\n```bash
-
-pnpm build --filter @mcp-ui/shared
-
-```
-
-```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ features:
   - title: ⚛️ Client SDK
     details: React components and hooks for seamless frontend integration. Render interactive UI resources with the ResourceRenderer component and handle UI actions effortlessly.
   - title: 🛠️ Server SDK
-    details: Powerful utilities to construct interactive resource blocks for MCP servers. Create HTML, React, Web Components, and external app UI with ergonomic API.
+    details: Powerful utilities to construct interactive UI Snippetsfor MCP servers. Create HTML, React, Web Components, and external app UI with ergonomic API.
   - title: 🔒 Secure
     details: All remote code executes in sandboxed iframes, ensuring host and user security while maintaining rich interactivity.
   - title: 🎨 Flexible
@@ -48,9 +48,9 @@ features:
 **Server Side** - Create interactive resources to return in your MCP tool results:
 
 ```typescript
-import { createHtmlResource } from '@mcp-ui/server';
+import { createUiSnippetResource } from '@mcp-ui/server';
 
-const interactiveForm = createHtmlResource({
+const interactiveForm = createUiSnippetResource({
   uri: 'ui://user-form/1',
   content: { 
     type: 'externalUrl', 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -35,7 +35,7 @@
 
 `mcp-ui` is a TypeScript SDK comprising two packages:
 
-* **`@mcp-ui/server`**: Utilities to generate UI snippets (`HtmlResourceBlock`) on your MCP server.
+* **`@mcp-ui/server`**: Utilities to generate UI snippets (`UiSnippetResource`) on your MCP server.
 * **`@mcp-ui/client`**: UI components (e.g., `<ResourceRenderer />`) to render those snippets and handle their events.
 
 Together, they let you define reusable UI snippets on the server side, seamlessly and securely render them in the client, and react to their actions in the MCP host environment.
@@ -44,11 +44,11 @@ Together, they let you define reusable UI snippets on the server side, seamlessl
 
 In essence, by using `mcp-ui` SDKs, servers and hosts can agree on contracts that enable them to create and render interactive UI snippets (as a path to a standardized UI approach in MCP).
 
-### HTML Resource Block
-The primary payload returned from the server to the client is the `HtmlResourceBlock`:
+### UI Snippet Resource
+The primary payload returned from the server to the client is the `UiSnippetResource`:
 
 ```ts
-interface HtmlResourceBlock {
+interface UiSnippetResource {
   type: 'resource';
   resource: {
     uri: string;       // ui://component/id
@@ -67,7 +67,7 @@ interface HtmlResourceBlock {
 
 ### Resource Renderer
 
-The HTML Resource Block is rendered in the `<ResourceRenderer />` component. It automatically detects the resource type and renders the appropriate component.
+The UI SnippetResource is rendered in the `<ResourceRenderer />` component. It automatically detects the resource type and renders the appropriate component.
 
 It accepts the following props:
 - **`resource`**: The resource object from an MCP response. Should include `uri`, `mimeType`, and content (`text`, `blob`, or `content`)
@@ -91,7 +91,7 @@ It accepts the following props:
 
 Rendered using the `<HtmlResource />` component, which displays content inside an `<iframe>`. This is suitable for self-contained HTML or embedding external apps.
 
-**`mimeType`**:
+*   **`mimeType`**:
     *   `text/html`: Renders inline HTML content.
     *   `text/uri-list`: Renders an external URL. MCP-UI uses the first valid URL.
 
@@ -99,7 +99,7 @@ Rendered using the `<HtmlResource />` component, which displays content inside a
 
 Rendered using the `<RemoteDomResource />` component, which uses Shopify's [`remote-dom`](https://github.com/Shopify/remote-dom). The server responds with a script that describes the UI and events. On the host, the script is securely rendered in a sandboxed iframe, and the UI changes are communicated to the host in JSON, where they're rendered using the host's component library. This is more flexible than iframes and allows for UIs that match the host's look-and-feel.
 
-**`mimeType`**: `application/vnd.mcp-ui.remote-dom; flavor={react | webcomponents}`
+* **`mimeType`**: `application/vnd.mcp-ui.remote-dom; flavor={react | webcomponents}`
 
 ### UI Action
 
@@ -123,7 +123,7 @@ yarn add @mcp-ui/server @mcp-ui/client
 1. **Server-side**: Build your resource blocks
 
    ```ts
-   import { createHtmlResource } from '@mcp-ui/server';
+   import { createUiSnippetResource } from '@mcp-ui/server';
    import {
     createRemoteComponent,
     createRemoteDocument,
@@ -131,14 +131,14 @@ yarn add @mcp-ui/server @mcp-ui/client
    } from '@remote-dom/core';
 
    // Inline HTML
-   const htmlResource = createHtmlResource({
+   const htmlResource = createUiSnippetResource({
      uri: 'ui://greeting/1',
      content: { type: 'rawHtml', htmlString: '<p>Hello, MCP UI!</p>' },
      delivery: 'text',
    });
 
    // External URL
-   const externalUrlResource = createHtmlResource({
+   const externalUrlResource = createUiSnippetResource({
      uri: 'ui://greeting/1',
      content: { type: 'externalUrl', iframeUrl: 'https://example.com' },
      delivery: 'text',
@@ -199,6 +199,7 @@ Host and user security is one of `mcp-ui`'s primary concerns. In all content typ
 - [X] Support Web Components
 - [X] Support Remote-DOM
 - [ ] Add component libraries (in progress)
+- [ ] Support additional frontend frameworks
 - [ ] Add declarative UI content type
 - [ ] Support generative UI?
       

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -35,7 +35,7 @@
 
 `mcp-ui` is a TypeScript SDK comprising two packages:
 
-* **`@mcp-ui/server`**: Utilities to generate UI snippets (`HtmlResourceBlock`) on your MCP server.
+* **`@mcp-ui/server`**: Utilities to generate UI snippets (`UiSnippetResource`) on your MCP server.
 * **`@mcp-ui/client`**: UI components (e.g., `<ResourceRenderer />`) to render those snippets and handle their events.
 
 Together, they let you define reusable UI snippets on the server side, seamlessly and securely render them in the client, and react to their actions in the MCP host environment.
@@ -44,11 +44,11 @@ Together, they let you define reusable UI snippets on the server side, seamlessl
 
 In essence, by using `mcp-ui` SDKs, servers and hosts can agree on contracts that enable them to create and render interactive UI snippets (as a path to a standardized UI approach in MCP).
 
-### HTML Resource Block
-The primary payload returned from the server to the client is the `HtmlResourceBlock`:
+### UI Snippet Resource
+The primary payload returned from the server to the client is the `UiSnippetResource`:
 
 ```ts
-interface HtmlResourceBlock {
+interface UiSnippetResource {
   type: 'resource';
   resource: {
     uri: string;       // ui://component/id
@@ -67,7 +67,7 @@ interface HtmlResourceBlock {
 
 ### Resource Renderer
 
-The HTML Resource Block is rendered in the `<ResourceRenderer />` component. It automatically detects the resource type and renders the appropriate component.
+The UI SnippetResource is rendered in the `<ResourceRenderer />` component. It automatically detects the resource type and renders the appropriate component.
 
 It accepts the following props:
 - **`resource`**: The resource object from an MCP response. Should include `uri`, `mimeType`, and content (`text`, `blob`, or `content`)
@@ -123,7 +123,7 @@ yarn add @mcp-ui/server @mcp-ui/client
 1. **Server-side**: Build your resource blocks
 
    ```ts
-   import { createHtmlResource } from '@mcp-ui/server';
+   import { createUiSnippetResource } from '@mcp-ui/server';
    import {
     createRemoteComponent,
     createRemoteDocument,
@@ -131,14 +131,14 @@ yarn add @mcp-ui/server @mcp-ui/client
    } from '@remote-dom/core';
 
    // Inline HTML
-   const htmlResource = createHtmlResource({
+   const htmlResource = createUiSnippetResource({
      uri: 'ui://greeting/1',
      content: { type: 'rawHtml', htmlString: '<p>Hello, MCP UI!</p>' },
      delivery: 'text',
    });
 
    // External URL
-   const externalUrlResource = createHtmlResource({
+   const externalUrlResource = createUiSnippetResource({
      uri: 'ui://greeting/1',
      content: { type: 'externalUrl', iframeUrl: 'https://example.com' },
      delivery: 'text',
@@ -199,6 +199,7 @@ Host and user security is one of `mcp-ui`'s primary concerns. In all content typ
 - [X] Support Web Components
 - [X] Support Remote-DOM
 - [ ] Add component libraries (in progress)
+- [ ] Support additional frontend frameworks
 - [ ] Add declarative UI content type
 - [ ] Support generative UI?
       

--- a/packages/server/src/__tests__/index.test.ts
+++ b/packages/server/src/__tests__/index.test.ts
@@ -1,14 +1,14 @@
-import { createHtmlResource } from '../index';
+import { createUiSnippetResource } from '../index';
 
 describe('@mcp-ui/server', () => {
-  describe('createHtmlResource', () => {
+  describe('createUiSnippetResource', () => {
     it('should create a text-based direct HTML resource', () => {
       const options = {
         uri: 'ui://test-html' as const,
         content: { type: 'rawHtml' as const, htmlString: '<p>Test</p>' },
         delivery: 'text' as const,
       };
-      const resource = createHtmlResource(options);
+      const resource = createUiSnippetResource(options);
       expect(resource.type).toBe('resource');
       expect(resource.resource.uri).toBe('ui://test-html');
       expect(resource.resource.mimeType).toBe('text/html');
@@ -22,7 +22,7 @@ describe('@mcp-ui/server', () => {
         content: { type: 'rawHtml' as const, htmlString: '<h1>Blob</h1>' },
         delivery: 'blob' as const,
       };
-      const resource = createHtmlResource(options);
+      const resource = createUiSnippetResource(options);
       expect(resource.resource.blob).toBe(
         Buffer.from('<h1>Blob</h1>').toString('base64'),
       );
@@ -38,7 +38,7 @@ describe('@mcp-ui/server', () => {
         },
         delivery: 'text' as const,
       };
-      const resource = createHtmlResource(options);
+      const resource = createUiSnippetResource(options);
       expect(resource.resource.uri).toBe('ui://test-url');
       expect(resource.resource.mimeType).toBe('text/uri-list');
       expect(resource.resource.text).toBe('https://example.com');
@@ -54,7 +54,7 @@ describe('@mcp-ui/server', () => {
         },
         delivery: 'blob' as const,
       };
-      const resource = createHtmlResource(options);
+      const resource = createUiSnippetResource(options);
       expect(resource.resource.mimeType).toBe('text/uri-list');
       expect(resource.resource.blob).toBe(
         Buffer.from('https://example.com/blob').toString('base64'),
@@ -68,7 +68,7 @@ describe('@mcp-ui/server', () => {
         content: { type: 'rawHtml' as const, htmlString: '<h1>Blob</h1>' },
         delivery: 'blob' as const,
       };
-      const resource = createHtmlResource(options);
+      const resource = createUiSnippetResource(options);
       expect(resource.resource.mimeType).toBe('text/html');
       expect(resource.resource.blob).toBe(
         Buffer.from('<h1>Blob</h1>').toString('base64'),
@@ -83,7 +83,7 @@ describe('@mcp-ui/server', () => {
         delivery: 'text' as const,
       };
       // @ts-expect-error We are intentionally passing an invalid URI to test the error.
-      expect(() => createHtmlResource(options)).toThrow(
+      expect(() => createUiSnippetResource(options)).toThrow(
         "MCP SDK: URI must start with 'ui://' when content.type is 'rawHtml'.",
       );
     });
@@ -98,7 +98,7 @@ describe('@mcp-ui/server', () => {
         delivery: 'text' as const,
       };
       // @ts-expect-error We are intentionally passing an invalid URI to test the error.
-      expect(() => createHtmlResource(options)).toThrow(
+      expect(() => createUiSnippetResource(options)).toThrow(
         "MCP SDK: URI must start with 'ui://' when content.type is 'externalUrl'.",
       );
     });
@@ -113,7 +113,7 @@ describe('@mcp-ui/server', () => {
         },
         delivery: 'text' as const,
       };
-      const resource = createHtmlResource(options);
+      const resource = createUiSnippetResource(options);
       expect(resource.type).toBe('resource');
       expect(resource.resource.uri).toBe('ui://test-remote-dom-react');
       expect(resource.resource.mimeType).toBe(
@@ -133,7 +133,7 @@ describe('@mcp-ui/server', () => {
         },
         delivery: 'blob' as const,
       };
-      const resource = createHtmlResource(options);
+      const resource = createUiSnippetResource(options);
       expect(resource.resource.mimeType).toBe(
         'application/vnd.mcp-ui.remote-dom+javascript; flavor=webcomponents',
       );
@@ -154,7 +154,7 @@ describe('@mcp-ui/server', () => {
         delivery: 'text' as const,
       };
       // @ts-expect-error We are intentionally passing an invalid URI to test the error.
-      expect(() => createHtmlResource(options)).toThrow(
+      expect(() => createUiSnippetResource(options)).toThrow(
         "MCP SDK: URI must start with 'ui://' when content.type is 'remoteDom'.",
       );
     });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * Defines the structure of an interactive HTML resource block
+ * Defines the structure of an interactive UI Snippet
  * that the server will send to the client.
  */
 
 // Import types first
 import {
   Base64BlobContent,
-  CreateHtmlResourceOptions,
+  CreateUiSnippetResourceOptions,
   HtmlTextContent,
   MimeType,
   UiActionResult,
@@ -17,7 +17,7 @@ import {
   UiActionResultToolCall,
 } from './types.js';
 
-export type HtmlResourceBlock = {
+export type UiSnippetResource = {
   type: 'resource';
   resource: HtmlTextContent | Base64BlobContent;
 };
@@ -57,14 +57,14 @@ function robustUtf8ToBase64(str: string): string {
 }
 
 /**
- * Creates an HtmlResourceBlock.
+ * Creates a UiSnippetResource.
  * This is the object that should be included in the 'content' array of a toolResult.
  * @param options Configuration for the interactive resource.
- * @returns An HtmlResourceBlock.
+ * @returns a UiSnippetResource.
  */
-export function createHtmlResource(
-  options: CreateHtmlResourceOptions,
-): HtmlResourceBlock {
+export function createUiSnippetResource(
+  options: CreateUiSnippetResourceOptions,
+): UiSnippetResource {
   let actualContentString: string;
   let mimeType: MimeType;
 
@@ -116,7 +116,7 @@ export function createHtmlResource(
     );
   }
 
-  let resource: HtmlResourceBlock['resource'];
+  let resource: UiSnippetResource['resource'];
 
   switch (options.delivery) {
     case 'text':
@@ -147,7 +147,7 @@ export function createHtmlResource(
 }
 
 export type {
-  CreateHtmlResourceOptions,
+  CreateUiSnippetResourceOptions,
   ResourceContentPayload,
   UiActionResult,
 } from './types.js';

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -31,7 +31,7 @@ export type ResourceContentPayload =
       flavor: 'react' | 'webcomponents';
     };
 
-export interface CreateHtmlResourceOptions {
+export interface CreateUiSnippetResourceOptions {
   uri: URI;
   content: ResourceContentPayload;
   delivery: 'text' | 'blob';


### PR DESCRIPTION
The original PoC centered around HTML. As MCP UI progresses, it's clear that we're no longer limited to HTML. The rename shifts the focus to the UI Snippet as opposed to HTML or "ResourceBlock".