### PR TITLE
docs: add GitMCP to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ yarn add @mcp-ui/server @mcp-ui/client
 
 ## 🎬 Quickstart
 
+You can use [GitMCP](https://gitmcp.io/badge/idosal/mcp-ui) to give your IDE access to `mcp-ui`'s latest documentation! 
+
 1. **Server-side**: Build your resource blocks
 
    ```ts

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@mcp-ui/server"><img src="https://img.shields.io/npm/v/@mcp-ui/server?label=server&color=green" alt="Server Version"></a>
   <a href="https://www.npmjs.com/package/@mcp-ui/client"><img src="https://img.shields.io/npm/v/@mcp-ui/client?label=client&color=blue" alt="Client Version"></a>
+  <a href="https://gitmcp.io/badge/idosal/mcp-ui"><img src="https://img.shields.io/endpoint?url=https://gitmcp.io/badge/idosal/mcp-ui" alt="MCP Documentation"></a>
 </p>
 
 <p align="center">

--- a/docs/src/guide/introduction.md
+++ b/docs/src/guide/introduction.md
@@ -4,6 +4,9 @@ Welcome to the MCP-UI documentation!
 
 This SDK provides tools for building Model Context Protocol (MCP) enabled applications with interactive UI components. It aims to standardize how models and tools can request the display of rich HTML interfaces within a client application.
 
+You can use GitMCP to give your IDE access to `mcp-ui`'s latest documentation! 
+<a href="https://gitmcp.io/badge/idosal/mcp-ui"><img src="https://img.shields.io/endpoint?url=https://gitmcp.io/badge/idosal/mcp-ui" alt="MCP Documentation"></a>
+
 ## What is MCP-UI?
 
 MCP-UI is a TypeScript SDK containing:

--- a/docs/src/guide/introduction.md
+++ b/docs/src/guide/introduction.md
@@ -4,7 +4,7 @@ Welcome to the MCP-UI documentation!
 
 This SDK provides tools for building Model Context Protocol (MCP) enabled applications with interactive UI components. It aims to standardize how models and tools can request the display of rich HTML interfaces within a client application.
 
-You can use GitMCP to give your IDE access to `mcp-ui`'s latest documentation! 
+You can use [GitMCP](https://gitmcp.io/badge/idosal/mcp-ui) to give your IDE access to `mcp-ui`'s latest documentation! 
 <a href="https://gitmcp.io/badge/idosal/mcp-ui"><img src="https://img.shields.io/endpoint?url=https://gitmcp.io/badge/idosal/mcp-ui" alt="MCP Documentation"></a>
 
 ## What is MCP-UI?

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -7,6 +7,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@mcp-ui/server"><img src="https://img.shields.io/npm/v/@mcp-ui/server?label=server&color=green" alt="Server Version"></a>
   <a href="https://www.npmjs.com/package/@mcp-ui/client"><img src="https://img.shields.io/npm/v/@mcp-ui/client?label=client&color=blue" alt="Client Version"></a>
+  <a href="https://gitmcp.io/badge/idosal/mcp-ui"><img src="https://img.shields.io/endpoint?url=https://gitmcp.io/badge/idosal/mcp-ui" alt="MCP Documentation"></a>
 </p>
 
 <p align="center">
@@ -121,6 +122,8 @@ yarn add @mcp-ui/server @mcp-ui/client
 ```
 
 ## 🎬 Quickstart
+
+You can use [GitMCP](https://gitmcp.io/badge/idosal/mcp-ui) to give your IDE access to `mcp-ui`'s latest documentation! 
 
 1. **Server-side**: Build your resource blocks
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -7,6 +7,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@mcp-ui/server"><img src="https://img.shields.io/npm/v/@mcp-ui/server?label=server&color=green" alt="Server Version"></a>
   <a href="https://www.npmjs.com/package/@mcp-ui/client"><img src="https://img.shields.io/npm/v/@mcp-ui/client?label=client&color=blue" alt="Client Version"></a>
+  <a href="https://gitmcp.io/badge/idosal/mcp-ui"><img src="https://img.shields.io/endpoint?url=https://gitmcp.io/badge/idosal/mcp-ui" alt="MCP Documentation"></a>
 </p>
 
 <p align="center">
@@ -121,6 +122,8 @@ yarn add @mcp-ui/server @mcp-ui/client
 ```
 
 ## 🎬 Quickstart
+
+You can use [GitMCP](https://gitmcp.io/badge/idosal/mcp-ui) to give your IDE access to `mcp-ui`'s latest documentation! 
 
 1. **Server-side**: Build your resource blocks
 


### PR DESCRIPTION
GitMCP is the suggested way to give IDEs access to mcp-ui's latest docs.