### PR TITLE
feat: support generic messages response

### DIFF
--- a/packages/client/src/components/HTMLResourceRenderer.tsx
+++ b/packages/client/src/components/HTMLResourceRenderer.tsx
@@ -39,22 +39,22 @@ export const HTMLResourceRenderer = ({
         if (!uiActionResult) {
           return;
         }
-        if (uiActionResult.requestId) {
+        if (uiActionResult.messageId) {
           event.source?.postMessage({
             type: InternalMessageType.UI_ACTION_RECEIVED,
             payload: {
-              requestId: uiActionResult.requestId,
+              messageId: uiActionResult.messageId,
               originalMessage: event.data,
             },
           });
         }
         try {
           const response = await onUIAction?.(uiActionResult);
-          if (uiActionResult.requestId) {
+          if (uiActionResult.messageId) {
             event.source?.postMessage({
               type: InternalMessageType.UI_ACTION_RESPONSE,
               payload: {
-                requestId: uiActionResult.requestId,
+                messageId: uiActionResult.messageId,
                 response,
                 originalMessage: event.data,
               },

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -6,7 +6,11 @@ export type UIActionType = 'tool' | 'prompt' | 'link' | 'intent' | 'notify';
 export const ALL_RESOURCE_CONTENT_TYPES = ['rawHtml', 'externalUrl', 'remoteDom'] as const;
 export type ResourceContentType = (typeof ALL_RESOURCE_CONTENT_TYPES)[number];
 
-export type UIActionResultToolCall = {
+type GenericActionMessage = {
+  requestId?: string;
+};
+
+export type UIActionResultToolCall = GenericActionMessage & {
   type: 'tool';
   payload: {
     toolName: string;
@@ -14,21 +18,21 @@ export type UIActionResultToolCall = {
   };
 };
 
-export type UIActionResultPrompt = {
+export type UIActionResultPrompt = GenericActionMessage & {
   type: 'prompt';
   payload: {
     prompt: string;
   };
 };
 
-export type UIActionResultLink = {
+export type UIActionResultLink = GenericActionMessage & {
   type: 'link';
   payload: {
     url: string;
   };
 };
 
-export type UIActionResultIntent = {
+export type UIActionResultIntent = GenericActionMessage & {
   type: 'intent';
   payload: {
     intent: string;
@@ -36,7 +40,7 @@ export type UIActionResultIntent = {
   };
 };
 
-export type UIActionResultNotification = {
+export type UIActionResultNotification = GenericActionMessage & {
   type: 'notify';
   payload: {
     message: string;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -7,7 +7,7 @@ export const ALL_RESOURCE_CONTENT_TYPES = ['rawHtml', 'externalUrl', 'remoteDom'
 export type ResourceContentType = (typeof ALL_RESOURCE_CONTENT_TYPES)[number];
 
 type GenericActionMessage = {
-  requestId?: string;
+  messageId?: string;
 };
 
 export type UIActionResultToolCall = GenericActionMessage & {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -133,6 +133,11 @@ export function postUIActionResult(result: UIActionResult): void {
   }
 }
 
+export const InternalMessageType = {
+  UI_ACTION_RECEIVED: 'ui-action-received',
+  UI_ACTION_RESPONSE: 'ui-action-response',
+};
+
 export function uiActionResultToolCall(
   toolName: string,
   params: Record<string, unknown>,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -39,7 +39,11 @@ export interface CreateUIResourceOptions {
 
 export type UIActionType = 'tool' | 'prompt' | 'link' | 'intent' | 'notify';
 
-export type UIActionResultToolCall = {
+type GenericActionMessage = {
+  requestId?: string;
+};
+
+export type UIActionResultToolCall = GenericActionMessage & {
   type: 'tool';
   payload: {
     toolName: string;
@@ -47,21 +51,21 @@ export type UIActionResultToolCall = {
   };
 };
 
-export type UIActionResultPrompt = {
+export type UIActionResultPrompt = GenericActionMessage & {
   type: 'prompt';
   payload: {
     prompt: string;
   };
 };
 
-export type UIActionResultLink = {
+export type UIActionResultLink = GenericActionMessage & {
   type: 'link';
   payload: {
     url: string;
   };
 };
 
-export type UIActionResultIntent = {
+export type UIActionResultIntent = GenericActionMessage & {
   type: 'intent';
   payload: {
     intent: string;
@@ -69,7 +73,7 @@ export type UIActionResultIntent = {
   };
 };
 
-export type UIActionResultNotification = {
+export type UIActionResultNotification = GenericActionMessage & {
   type: 'notify';
   payload: {
     message: string;

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -40,7 +40,7 @@ export interface CreateUIResourceOptions {
 export type UIActionType = 'tool' | 'prompt' | 'link' | 'intent' | 'notify';
 
 type GenericActionMessage = {
-  requestId?: string;
+  messageId?: string;
 };
 
 export type UIActionResultToolCall = GenericActionMessage & {


### PR DESCRIPTION
This supports returning responses for every message that contains a `messageId`, given the `onUIAction` was provided:
1. An immediate "ack" response of type `ui-action-received` - so that the calling frame will know that the rendering environment is using `mcp-ui`
2. A respose message of type `ui-action-response` with the result of `onUIAction`