### PR TITLE
fix: change internal names (unused, not breaking)

### DIFF
--- a/docs/src/guide/client/html-resource.md
+++ b/docs/src/guide/client/html-resource.md
@@ -32,9 +32,8 @@ The component accepts the following props:
   If you don't provide a callback for a specific type, the default handler will be used.
   
   **Asynchronous Response Handling**: When a message includes a `messageId` field, the iframe will automatically receive response messages:
-  - `ui-action-received`: Sent immediately when the message is received
-  - `ui-action-response`: Sent when your callback resolves successfully  
-  - `ui-action-error`: Sent if your callback throws an error
+  - `ui-message-received`: Sent immediately when the message is received
+  - `ui-message-response`: Sent when your callback resolves successfully or throws an error
   
   See [Protocol Details](../protocol-details.md#asynchronous-communication-with-message-ids) for complete examples.
 - **`style`**: (Optional) Custom styles for the iframe.

--- a/docs/src/guide/client/resource-renderer.md
+++ b/docs/src/guide/client/resource-renderer.md
@@ -43,7 +43,7 @@ interface UIResourceRendererProps {
   { type: 'link', payload: { url: string }, messageId?: string }
   ```
   
-  **Asynchronous Communication**: When actions include a `messageId`, the iframe automatically receives response messages (`ui-action-received`, `ui-action-response`, `ui-action-error`). See [Protocol Details](../protocol-details.md#asynchronous-communication-with-message-ids) for examples.
+  **Asynchronous Communication**: When actions include a `messageId`, the iframe automatically receives response messages (`ui-message-received`, `ui-message-response`). See [Protocol Details](../protocol-details.md#asynchronous-communication-with-message-ids) for examples.
 - **`supportedContentTypes`**: Optional array to restrict which content types are allowed (`['rawHtml', 'externalUrl', 'remoteDom']`)
 - **`htmlProps`**: Optional props for the `<HTMLResourceRenderer>`
   - **`style`**: Optional custom styles for iframe-based resources

--- a/docs/src/guide/client/usage-examples.md
+++ b/docs/src/guide/client/usage-examples.md
@@ -340,24 +340,24 @@ const AsyncExampleApp: React.FC = () => {
             const request = pendingRequests.get(message.messageId);
             
             switch (message.type) {
-              case 'ui-action-received':
+              case 'ui-message-received':
                 updateStatus('Request acknowledged, processing...', 'pending');
                 break;
                 
-              case 'ui-action-response':
+              case 'ui-message-response':
+                if (message.payload.error) {
+                  updateStatus('Error occurred!', 'error');
+                  updateResult(\`
+                    <h4>Error:</h4>
+                    <div style="color: red;">\${JSON.stringify(message.payload.error, null, 2)}</div>
+                  \`);
+                  pendingRequests.delete(message.messageId);
+                  break;
+                }
                 updateStatus('Completed successfully!', 'success');
                 updateResult(\`
                   <h4>Response:</h4>
                   <pre>\${JSON.stringify(message.payload.response, null, 2)}</pre>
-                \`);
-                pendingRequests.delete(message.messageId);
-                break;
-                
-              case 'ui-action-error':
-                updateStatus('Error occurred!', 'error');
-                updateResult(\`
-                  <h4>Error:</h4>
-                  <div style="color: red;">\${JSON.stringify(message.payload.error, null, 2)}</div>
                 \`);
                 pendingRequests.delete(message.messageId);
                 break;

--- a/docs/src/guide/protocol-details.md
+++ b/docs/src/guide/protocol-details.md
@@ -142,7 +142,7 @@ For iframe content that needs to handle asynchronous responses, you can include 
    ```javascript
    // The iframe receives this message back
    {
-     type: 'ui-action-received',
+     type: 'ui-message-received',
      messageId: 'unique-request-id-123',
    }
    ```
@@ -151,7 +151,7 @@ For iframe content that needs to handle asynchronous responses, you can include 
    ```javascript
    // The iframe receives the actual response
    {
-     type: 'ui-action-response',
+     type: 'ui-message-response',
      messageId: 'unique-request-id-123',
      payload: {
        response: { /* the result from onUIAction */ }
@@ -163,7 +163,7 @@ For iframe content that needs to handle asynchronous responses, you can include 
    ```javascript
    // The iframe receives the error
    {
-     type: 'ui-action-error',
+     type: 'ui-message-response',
      messageId: 'unique-request-id-123',
      payload: {
        error: { /* the error object */ }
@@ -223,19 +223,19 @@ For iframe content that needs to handle asynchronous responses, you can include 
     const request = pendingRequests.get(message.messageId);
     
     switch (message.type) {
-      case 'ui-action-received':
+      case 'ui-message-received':
         statusEl.textContent = 'Request acknowledged, processing...';
         break;
         
-      case 'ui-action-response':
+      case 'ui-message-response':
+        if (message.payload.error) {
+          statusEl.textContent = 'Error occurred!';
+          resultEl.innerHTML = `<div style="color: red;">Error: ${JSON.stringify(message.payload.error)}</div>`;
+          pendingRequests.delete(message.messageId);
+          break;
+        }
         statusEl.textContent = 'Completed successfully!';
         resultEl.innerHTML = `<pre>${JSON.stringify(message.payload.response, null, 2)}</pre>`;
-        pendingRequests.delete(message.messageId);
-        break;
-        
-      case 'ui-action-error':
-        statusEl.textContent = 'Error occurred!';
-        resultEl.innerHTML = `<div style="color: red;">Error: ${JSON.stringify(message.payload.error)}</div>`;
         pendingRequests.delete(message.messageId);
         break;
     }
@@ -247,9 +247,8 @@ For iframe content that needs to handle asynchronous responses, you can include 
 
 The following internal message types are available as constants:
 
-- `InternalMessageType.UI_ACTION_RECEIVED` (`'ui-action-received'`)
-- `InternalMessageType.UI_ACTION_RESPONSE` (`'ui-action-response'`)  
-- `InternalMessageType.UI_ACTION_ERROR` (`'ui-action-error'`)
+- `InternalMessageType.UI_MESSAGE_RECEIVED` (`'ui-message-received'`)
+- `InternalMessageType.UI_MESSAGE_RESPONSE` (`'ui-message-response'`)
 
 These types are exported from both `@mcp-ui/client` and `@mcp-ui/server` packages.
 

--- a/sdks/typescript/client/src/components/HTMLResourceRenderer.tsx
+++ b/sdks/typescript/client/src/components/HTMLResourceRenderer.tsx
@@ -16,9 +16,8 @@ export type HTMLResourceRendererProps = {
 };
 
 const InternalMessageType = {
-  UI_ACTION_RECEIVED: 'ui-action-received',
-  UI_ACTION_RESPONSE: 'ui-action-response',
-  UI_ACTION_ERROR: 'ui-action-error',
+  UI_MESSAGE_RECEIVED: 'ui-message-received',
+  UI_MESSAGE_RESPONSE: 'ui-message-response',
 
   UI_SIZE_CHANGE: 'ui-size-change',
 
@@ -118,19 +117,19 @@ export const HTMLResourceRenderer = ({
           return;
         }
 
-        // return the "ui-action-received" message only if the onUIAction callback is provided
+        // return the "ui-message-received" message only if the onUIAction callback is provided
         // otherwise we cannot know that the message was received by the client
         if (onUIAction) {
           const messageId = uiActionResult.messageId;
-          postToFrame(InternalMessageType.UI_ACTION_RECEIVED, source, origin, messageId);
+          postToFrame(InternalMessageType.UI_MESSAGE_RECEIVED, source, origin, messageId);
           try {
             const response = await onUIAction(uiActionResult);
-            postToFrame(InternalMessageType.UI_ACTION_RESPONSE, source, origin, messageId, {
+            postToFrame(InternalMessageType.UI_MESSAGE_RESPONSE, source, origin, messageId, {
               response,
             });
           } catch (err) {
             console.error('Error handling UI action result in HTMLResourceRenderer:', err);
-            postToFrame(InternalMessageType.UI_ACTION_ERROR, source, origin, messageId, {
+            postToFrame(InternalMessageType.UI_MESSAGE_RESPONSE, source, origin, messageId, {
               error: err,
             });
           }

--- a/sdks/typescript/server/src/index.ts
+++ b/sdks/typescript/server/src/index.ts
@@ -136,9 +136,8 @@ export function postUIActionResult(result: UIActionResult): void {
 }
 
 export const InternalMessageType = {
-  UI_ACTION_RECEIVED: 'ui-action-received',
-  UI_ACTION_RESPONSE: 'ui-action-response',
-  UI_ACTION_ERROR: 'ui-action-error',
+  UI_MESSAGE_RECEIVED: 'ui-message-received',
+  UI_MESSAGE_RESPONSE: 'ui-message-response',
 
   UI_SIZE_CHANGE: 'ui-size-change',
 


### PR DESCRIPTION
1. Rename:
    1.  `ui-action-received`-> `ui-message-received`
    2. `ui-action-response` -> `ui-message-response`
2. Remove the redundant `ui-action-error` type, and instead send the error (if any) in the `ui-message-response` message.

This API is not yet used anywhere, so this is not a breaking change.