### PR TITLE
feat: add sandbox permissions instead of an override

### DIFF
--- a/docs/src/guide/client/resource-renderer.md
+++ b/docs/src/guide/client/resource-renderer.md
@@ -59,6 +59,9 @@ interface UIResourceRendererProps {
 - **`htmlProps`**: Optional props for the `<HTMLResourceRenderer>`
   - **`style`**: Optional custom styles for iframe-based resources
   - **`proxy`**: Optional. A URL to a static "proxy" script for rendering external URLs. See [Using a Proxy for External URLs](./using-a-proxy.md) for details.
+  - **`sandboxPermissions`**: Optional string to add additional iframe sandbox permissions. These are added to the default sandbox permissions:
+    - For external URLs: `'allow-scripts allow-same-origin'`
+    - For raw HTML iframes: `'allow-scripts'`
   - **`iframeProps`**: Optional props passed to iframe elements (for HTML/URL resources)
     - **`ref`**: Optional React ref to access the underlying iframe element
   - **`iframeRenderData`**: Optional `Record<string, unknown>` to pass data to the iframe upon rendering. This enables advanced use cases where the parent application needs to provide initial state or configuration to the sandboxed iframe content.

--- a/sdks/typescript/client/README.md
+++ b/sdks/typescript/client/README.md
@@ -91,6 +91,7 @@ It accepts the following props:
 - **`supportedContentTypes`**: Optional array to restrict which content types are allowed (`['rawHtml', 'externalUrl', 'remoteDom']`)
 - **`htmlProps`**: Optional props for the internal `<HTMLResourceRenderer>`
   - **`style`**: Optional custom styles for the iframe
+  - **`sandboxPermissions`**: Optional additional iframe sandbox permissions (added to defaults: `'allow-scripts'` for raw HTML, `'allow-scripts allow-same-origin'` for external URLs)
   - **`iframeProps`**: Optional props passed to the iframe element
 - **`remoteDomProps`**: Optional props for the internal `<RemoteDOMResourceRenderer>`
   - **`library`**: Optional component library for Remote DOM resources (defaults to `basicComponentLibrary`)

--- a/sdks/typescript/client/src/components/__tests__/HTMLResourceRenderer.test.tsx
+++ b/sdks/typescript/client/src/components/__tests__/HTMLResourceRenderer.test.tsx
@@ -164,6 +164,48 @@ https://example.com/backup
     render(<HTMLResourceRenderer {...props} />);
     expect(screen.getByText('No valid URLs found in uri-list content.')).toBeInTheDocument();
   });
+
+  it('sets default sandbox permissions if none are provided', () => {
+    const props: HTMLResourceRendererProps = {
+      resource: { mimeType: 'text/html', text: '<p>Hello Test</p>' },
+      onUIAction: mockOnUIAction,
+    };
+    render(<HTMLResourceRenderer {...props} />);
+    const iframe = screen.getByTitle('MCP HTML Resource (Embedded Content)') as HTMLIFrameElement;
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+  });
+
+  it('sets default sandbox permissions if none are provided - external URL', () => {
+    const props: HTMLResourceRendererProps = {
+      resource: { mimeType: 'text/uri-list', text: 'https://example.com/app' },
+      onUIAction: mockOnUIAction,
+    };
+    render(<HTMLResourceRenderer {...props} />);
+    const iframe = screen.getByTitle('MCP HTML Resource (URL)') as HTMLIFrameElement;
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin');
+  });
+
+  it('uses the sandbox permissions if provided', () => {
+    const props: HTMLResourceRendererProps = {
+      resource: { mimeType: 'text/html', text: '<p>Hello Test</p>' },
+      onUIAction: mockOnUIAction,
+      sandboxPermissions: 'allow-forms',
+    };
+    render(<HTMLResourceRenderer {...props} />);
+    const iframe = screen.getByTitle('MCP HTML Resource (Embedded Content)') as HTMLIFrameElement;
+    expect(iframe.getAttribute('sandbox')).toBe('allow-forms allow-scripts');
+  });
+
+  it('uses the sandbox permissions if provided - external URL', () => {
+    const props: HTMLResourceRendererProps = {
+      resource: { mimeType: 'text/uri-list', text: 'https://example.com/app' },
+      onUIAction: mockOnUIAction,
+      sandboxPermissions: 'allow-forms',
+    };
+    render(<HTMLResourceRenderer {...props} />);
+    const iframe = screen.getByTitle('MCP HTML Resource (URL)') as HTMLIFrameElement;
+    expect(iframe.getAttribute('sandbox')).toBe('allow-forms allow-scripts allow-same-origin');
+  });
 });
 
 describe('HTMLResource iframe communication', () => {


### PR DESCRIPTION
This PR adresses #68 , adding a `sandboxPermissions` prop that adds to the default permissions for each iframe type, and does not override them.
```tsx
<UIResourceRenderer
  resource={mcpResource.resource}
  supportedContentTypes={['rawHtml']}
  onUIAction={handleUIAction}
  htmlProps={{
    sandboxPermissions: 'allow-forms',
  }}
/>
```
This will create `'allow-forms allow-scripts allow-same-origin'` for external URL iframes, and `'allow-forms allow-scripts'` for rawHtml (`srcDoc` based) iframes.