### PR TITLE
fix: move react dependencies to be peer dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,12 +397,6 @@ importers:
       '@remote-dom/react':
         specifier: ^1.2.2
         version: 1.2.2(@preact/signals-core@1.10.0)(react@18.3.1)
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.0.0
@@ -422,6 +416,12 @@ importers:
       jsdom:
         specifier: ^22.0.0
         version: 22.1.0
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1

--- a/sdks/typescript/client/package.json
+++ b/sdks/typescript/client/package.json
@@ -23,9 +23,7 @@
     "@quilted/threads": "^3.1.3",
     "@r2wc/react-to-web-component": "^2.0.4",
     "@remote-dom/core": "^1.8.0",
-    "@remote-dom/react": "^1.2.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "@remote-dom/react": "^1.2.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.0.0",
@@ -34,11 +32,17 @@
     "@vitejs/plugin-react": "^4.0.0",
     "esbuild": "^0.25.5",
     "jsdom": "^22.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "rimraf": "^6.0.1",
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
     "vite-plugin-dts": "^3.6.0",
     "vitest": "^1.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19"
   },
   "scripts": {
     "prepublishOnly": "pnpm run build",


### PR DESCRIPTION
This PR moves `react` and `react-dom` to be peer dependencies, solving issues like https://github.com/idosal/mcp-ui/issues/90 where there is a mismatch in React versions between the library and the host.
This kind of move is usually a breaking change - but since we can assume that all the consumers of the React SDK already have React installed in their dependencies (since they need to render `<UIResourceRenderer>` somehow) - this _might_ not be a problem.