### PR TITLE
ci: fix concurrent version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+      - name: Pull latest changes from main
+        run: git pull origin main
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with: { version: 10 }
@@ -173,6 +175,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+      - name: Pull latest changes from main
+        run: git pull origin main
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with: { version: 10 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - name: Pull latest changes from main
-        run: git pull origin main
+        run: git pull --rebase origin main
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with: { version: 10 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - name: Pull latest changes from main
-        run: git pull origin main
+        run: git pull --rebase origin main
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with: { version: 10 }


### PR DESCRIPTION
When multiple SDKs required a bump, the first would invalidate the others due to their now stale branches. This PR adds another `pull` before publishing.