### PR TITLE
fix: update UIResourceRenderer to use EmbeddedResource type

### DIFF
--- a/sdks/typescript/client/src/components/UIResourceRenderer.tsx
+++ b/sdks/typescript/client/src/components/UIResourceRenderer.tsx
@@ -1,18 +1,20 @@
-import type { Resource } from '@modelcontextprotocol/sdk/types.js';
+import type { EmbeddedResource } from '@modelcontextprotocol/sdk/types.js';
 import { ResourceContentType, UIActionResult } from '../types';
 import { HTMLResourceRenderer, HTMLResourceRendererProps } from './HTMLResourceRenderer';
 import { RemoteDOMResourceProps, RemoteDOMResourceRenderer } from './RemoteDOMResourceRenderer';
 import { basicComponentLibrary } from '../remote-dom/component-libraries/basic';
 
 export type UIResourceRendererProps = {
-  resource: Partial<Resource>;
+  resource: Partial<EmbeddedResource>;
   onUIAction?: (result: UIActionResult) => Promise<unknown>;
   supportedContentTypes?: ResourceContentType[];
   htmlProps?: Omit<HTMLResourceRendererProps, 'resource' | 'onUIAction'>;
   remoteDomProps?: Omit<RemoteDOMResourceProps, 'resource' | 'onUIAction'>;
 };
 
-function getContentType(resource: Partial<Resource>): ResourceContentType | undefined {
+function getContentType(
+  resource: Partial<EmbeddedResource['resource']>,
+): ResourceContentType | undefined {
   if (resource.contentType) {
     return resource.contentType as ResourceContentType;
   }


### PR DESCRIPTION
# Fix: Update UIResourceRenderer to use EmbeddedResource type instead of Resource

## Problem
While implementing the `UIResourceRenderer` component in a client application, I discovered that the component was using the generic `Resource` type from the MCP SDK instead of the more specific `EmbeddedResource` type. This caused type mismatches when working with the MCP [EmbeddedResource schema](https://modelcontextprotocol.io/specification/draft/schema#embeddedresource).

## Root Cause
The `UIResourceRenderer` component was originally typed to accept `Partial<Resource>`, but according to the MCP specification, embedded resources in prompts and tool call results should use the `EmbeddedResource` type, which has a different structure:

- `Resource` is the base resource type used for resource listings and operations
- `EmbeddedResource` is specifically designed for resources that are embedded into prompts or tool call results, with the structure:
  ```typescript
  interface EmbeddedResource {
    type: "resource";
    resource: TextResourceContents | BlobResourceContents;
    _meta?: { [key: string]: unknown };
    annotations?: Annotations;
  }
  ```

## Changes Made
- Updated import statement to use `EmbeddedResource` instead of `Resource` from `@modelcontextprotocol/sdk/types.js`
- Changed `UIResourceRendererProps.resource` type from `Partial<Resource>` to `Partial<EmbeddedResource>`
- Updated `getContentType` function parameter type from `Partial<Resource>` to `Partial<EmbeddedResource['resource']>`

## Impact
This change ensures proper type alignment with the MCP specification for embedded resources, providing better type safety and preventing runtime errors when the component receives properly typed `EmbeddedResource` objects from MCP tool call results or prompts.

## Testing
The component maintains backward compatibility as `EmbeddedResource` contains the necessary `resource` property that the component logic depends on, while providing more accurate typing for the expected MCP protocol usage.
